### PR TITLE
Basic integer normalizer

### DIFF
--- a/src/main/java/org/spectra/cluster/normalizer/BasicIntegerNormalizer.java
+++ b/src/main/java/org/spectra/cluster/normalizer/BasicIntegerNormalizer.java
@@ -1,0 +1,24 @@
+package org.spectra.cluster.normalizer;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * This basic normalizer simply multiplies the passed values by a constant
+ * and returns the rounded result.
+ */
+@Data
+public class BasicIntegerNormalizer implements IIntegerNormalizer {
+    /**
+     * This is optimised for m/z values.
+     */
+    public static final int MZ_CONSTANT = 100000;
+    private final int constant;
+
+    @Override
+    public int[] binDoubles(List<Double> valuesToBin) {
+        int[] convertedValues = valuesToBin.stream().mapToInt(value -> (int) Math.round(value * constant)).toArray();
+        return convertedValues;
+    }
+}

--- a/src/test/java/org/spectra/cluster/normalizer/BasicIntegerNormalizerTest.java
+++ b/src/test/java/org/spectra/cluster/normalizer/BasicIntegerNormalizerTest.java
@@ -1,0 +1,24 @@
+package org.spectra.cluster.normalizer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class BasicIntegerNormalizerTest {
+    @Test
+    public void testBasicNormalizer() {
+        double[] doublesToConvert = {0.1552, 100.2523, 5000.125, 299.99};
+        BasicIntegerNormalizer normalizer = new BasicIntegerNormalizer(BasicIntegerNormalizer.MZ_CONSTANT);
+
+        int[] convertedValues = normalizer.binDoubles(Arrays.stream(doublesToConvert).mapToObj(Double::new).collect(Collectors.toList()));
+
+        Assert.assertEquals(4, convertedValues.length);
+        Assert.assertEquals(15520, convertedValues[0]);
+        Assert.assertEquals(10025230, convertedValues[1]);
+        Assert.assertEquals(500012500, convertedValues[2]);
+        Assert.assertEquals(29999000, convertedValues[3]);
+
+    }
+}


### PR DESCRIPTION
simply multiplies the passed doubles with a constant. Currently mainly intended to be used for m/z values.