### PR TITLE
Fixes #24 Added new normalizer to normalize peak intensities

### DIFF
--- a/src/main/java/org/spectra/cluster/io/MzSpectraReader.java
+++ b/src/main/java/org/spectra/cluster/io/MzSpectraReader.java
@@ -6,10 +6,7 @@ import org.spectra.cluster.filter.IFilter;
 import org.spectra.cluster.model.commons.IteratorConverter;
 import org.spectra.cluster.model.spectra.BinarySpectrum;
 import org.spectra.cluster.model.spectra.IBinarySpectrum;
-import org.spectra.cluster.normalizer.BasicIntegerNormalizer;
-import org.spectra.cluster.normalizer.FactoryNormalizer;
-import org.spectra.cluster.normalizer.IIntegerNormalizer;
-import org.spectra.cluster.normalizer.SequestBinner;
+import org.spectra.cluster.normalizer.*;
 import uk.ac.ebi.pride.tools.apl_parser.AplFile;
 import uk.ac.ebi.pride.tools.dta_parser.DtaFile;
 import uk.ac.ebi.pride.tools.jmzreader.JMzReader;
@@ -134,7 +131,7 @@ public class MzSpectraReader {
      * @param file File
      */
     public MzSpectraReader(File file) throws Exception {
-        this(file, new SequestBinner(), new SequestBinner(), new BasicIntegerNormalizer(), new HighestPeakPerBinFilter());
+        this(file, new SequestBinner(), new MaxPeakNormalizer(), new BasicIntegerNormalizer(), new HighestPeakPerBinFilter());
     }
 
     /**

--- a/src/main/java/org/spectra/cluster/normalizer/MaxPeakNormalizer.java
+++ b/src/main/java/org/spectra/cluster/normalizer/MaxPeakNormalizer.java
@@ -1,0 +1,39 @@
+package org.spectra.cluster.normalizer;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Normalizes peaks' intensities by setting the maximum
+ * peak to a fixed number.
+ */
+public class MaxPeakNormalizer implements IIntegerNormalizer {
+    public static final int MAX_INTENSITY = 100000;
+
+    @Getter
+    private final int targetMaxIntensity;
+
+    public MaxPeakNormalizer(int maxIntensity) {
+        this.targetMaxIntensity = maxIntensity;
+    }
+
+    public MaxPeakNormalizer() {
+        this(MAX_INTENSITY);
+    }
+
+    @Override
+    public int[] binDoubles(List<Double> valuesToBin) {
+        if (valuesToBin.size() < 1) {
+            return new int[0];
+        }
+
+        // get the max intensity
+        double maxIntensity = valuesToBin.stream().mapToDouble(Double::doubleValue).max().getAsDouble();
+
+        // get the ratio to use to convert the intensities
+        double ratio = (double) targetMaxIntensity / maxIntensity;
+
+        return valuesToBin.stream().mapToInt(value -> (int) Math.round(value * ratio)).toArray();
+    }
+}

--- a/src/test/java/org/spectra/cluster/normalizer/MaxPeakNormalizerTest.java
+++ b/src/test/java/org/spectra/cluster/normalizer/MaxPeakNormalizerTest.java
@@ -1,0 +1,26 @@
+package org.spectra.cluster.normalizer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class MaxPeakNormalizerTest {
+    @Test
+    public void testNormalizer() {
+        double[] intensitiesToNormalize = {15.1254, 1025.241, 12035.123, 1203.4, 123352.92};
+
+        IIntegerNormalizer normalizer = new MaxPeakNormalizer();
+
+        int[] normalizedValues = normalizer.binDoubles(Arrays.stream(intensitiesToNormalize).boxed().collect(Collectors.toCollection(ArrayList::new)));
+
+        Assert.assertEquals(intensitiesToNormalize.length, normalizedValues.length);
+
+        Assert.assertEquals(MaxPeakNormalizer.MAX_INTENSITY, normalizedValues[4]);
+        Assert.assertEquals(12, normalizedValues[0]);
+        Assert.assertEquals(831, normalizedValues[1]);
+        Assert.assertEquals(9757, normalizedValues[2]);
+    }
+}


### PR DESCRIPTION
Added an intensity normalizer and fixed the bug in the io class that the intensities were processed using the Sequest normalizer.