### PR TITLE
Adapted MzSpectraReader to support ISpectrumListener

### DIFF
--- a/src/main/java/org/spectra/cluster/cdf/SpectraPerBinNumberComparisonAssessor.java
+++ b/src/main/java/org/spectra/cluster/cdf/SpectraPerBinNumberComparisonAssessor.java
@@ -1,5 +1,8 @@
 package org.spectra.cluster.cdf;
 
+import org.spectra.cluster.io.spectra.ISpectrumListener;
+import org.spectra.cluster.model.spectra.IBinarySpectrum;
+
 /**
  * This INumberOfComparisonAssessor assess the number of
  * comparisons based on all spectra within a bin. For this
@@ -10,7 +13,7 @@ package org.spectra.cluster.cdf;
  *
  * Created by jg on 13.10.17.
  */
-public class SpectraPerBinNumberComparisonAssessor implements INumberOfComparisonAssessor {
+public class SpectraPerBinNumberComparisonAssessor implements INumberOfComparisonAssessor, ISpectrumListener {
     private final double windowSize;
     private final int[] spectraPerBin;
     private final int maxBin;
@@ -47,6 +50,11 @@ public class SpectraPerBinNumberComparisonAssessor implements INumberOfCompariso
     public synchronized void countSpectrum(int precursorMz) {
         int bin = getBinForSpectrum(precursorMz);
         spectraPerBin[bin] += 1;
+    }
+
+    @Override
+    public void onNewSpectrum(IBinarySpectrum spectrum) {
+        countSpectrum(spectrum.getPrecursorMz());
     }
 
     /**

--- a/src/main/java/org/spectra/cluster/io/spectra/ISpectrumListener.java
+++ b/src/main/java/org/spectra/cluster/io/spectra/ISpectrumListener.java
@@ -1,0 +1,19 @@
+package org.spectra.cluster.io.spectra;
+
+import org.spectra.cluster.model.spectra.IBinarySpectrum;
+
+/**
+ * This interface describes classes that listen to
+ * new spectra being processed.
+ *
+ * It is intended to be used to, for example, count all
+ * spectra within a certain precursor m/z region.
+ */
+public interface ISpectrumListener {
+    /**
+     * This function is called whenever a new spectrum is
+     * being processed (generally, when it is loaded).
+     * @param spectrum The newly processed spectrum
+     */
+    void onNewSpectrum(IBinarySpectrum spectrum);
+}

--- a/src/main/java/org/spectra/cluster/io/spectra/MzSpectraReader.java
+++ b/src/main/java/org/spectra/cluster/io/spectra/MzSpectraReader.java
@@ -27,8 +27,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Iterator;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -53,6 +52,8 @@ public class MzSpectraReader {
 
     /** Pattern for validating mzXML format */
     private static final Pattern mzXmlHeaderPattern = Pattern.compile("^[^<]*(<\\?xml [^>]*>\\s*(<!--[^>]*-->\\s*)*)?<(mzXML) xmlns=.*", Pattern.MULTILINE);
+
+    private final Set<ISpectrumListener> listener = new HashSet<>(5);
 
     /** This enum type Capture the two file types supported in Spectra Cluster **/
     public enum MzFileType{
@@ -207,6 +208,11 @@ public class MzSpectraReader {
                 propertyStorage.storeProperty(s.getUUI(), StoredProperties.CHARGE, String.valueOf(spectrum.getPrecursorCharge()));
             }
 
+            // call the listeners
+            for (ISpectrumListener spectrumListener : listener) {
+                spectrumListener.onNewSpectrum(s);
+            }
+
             return peaksPerMzWindowFilter.apply(s);
         });
     }
@@ -294,6 +300,19 @@ public class MzSpectraReader {
 
     }
 
+    /**
+     * Add a new listener that will receive every loaded spectrum.
+     *
+     * The listener is called **after** any pre-processing of the spectrum
+     * was performed.
+     *
+     * @param newListener The new listener
+     */
+    public void addSpectrumListener(ISpectrumListener newListener) {
+        listener.add(newListener);
+    }
 
-
+    public void removeSpectrumListener(ISpectrumListener theListener) {
+        listener.remove(theListener);
+    }
 }


### PR DESCRIPTION
This functionality is intended to extract spectrum properties while they are loaded.