### PR TITLE
Adapted CLI to use thresholds and output filename passed on the CLI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # spectra-cluster-2
 A complete re-write of the spectra-cluster codebase
+
+## Release process using jgitflow
+
+Releases are currently performed using the
+[jgitflow](https://bitbucket.org/atlassian/jgit-flow/wiki/Home) plugin.
+
+The `jgitflow` plugin (or git-flow in general) uses different branches
+to keep track of the development cycle. As in our current concept,
+the `master` branch only contains stable code, while development is
+done in the `develop` branch.
+
+Additionally, separate branches can be created to start working on
+a `feature` or a `hotfix` (these terms are used by git-flow).
+
+To start a release, use `mvn jgitflow:release-start`. This will
+create a new branch for that releast. Once work on the release
+is complete, `mvn jgitflow:release-finish` can be used to finally
+create it.

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>external.atlassian.jgitflow</groupId>
+                <artifactId>jgitflow-maven-plugin</artifactId>
+                <version>1.0-m5.1</version>
+                <configuration>
+                    <noDeploy>true</noDeploy>
+                </configuration>
+            </plugin>
         </plugins>
 
     </build>

--- a/src/main/java/org/spectra/cluster/engine/GreedyClusteringEngine.java
+++ b/src/main/java/org/spectra/cluster/engine/GreedyClusteringEngine.java
@@ -153,6 +153,7 @@ public class GreedyClusteringEngine implements IClusteringEngine {
                 }
 
                 // calculate the score
+                // TODO: in the previous version we stored all filtered consensus spectra of existing clusters
                 IBinarySpectrum existingSpectrum = comparisonFilter.apply(existingCluster.getConsensusSpectrum());
                 double similarity = similarityMeasure.correlation(filteredSpectrumToAdd, existingSpectrum);
 

--- a/src/main/java/org/spectra/cluster/io/spectra/MzSpectraReader.java
+++ b/src/main/java/org/spectra/cluster/io/spectra/MzSpectraReader.java
@@ -239,7 +239,9 @@ public class MzSpectraReader {
     public Iterator<IBinarySpectrum> readBinarySpectraIterator(IPropertyStorage propertyStorage) {
         Stream<Tuple<File, Iterator<Spectrum>>> iteratorStream = inputFiles
                 .entrySet().stream()
-                .map(x -> new Tuple<>(x.getKey(), x.getValue().getSpectrumIterator())).collect(Collectors.toList()).stream();
+                .map(x -> new Tuple<>(x.getKey(), x.getValue().getSpectrumIterator()))
+                .collect(Collectors.toList())
+                .stream();
 
         return new StreamIteratorConverter<Stream<ITuple>, IBinarySpectrum>(iteratorStream, tupleSpectrum -> {
 
@@ -253,7 +255,7 @@ public class MzSpectraReader {
 
             IBinarySpectrum s = new BinarySpectrum(
                     ((BasicIntegerNormalizer)precursorNormalizer).binValue(spectrum.getPrecursorMZ()),
-                    spectrum.getPrecursorCharge(),
+                    (spectrum.getPrecursorCharge() != null) ? spectrum.getPrecursorCharge() : 0,
                     factory.normalizePeaks(spectrum.getPeakList()));
 
             // save spectrum properties

--- a/src/main/java/org/spectra/cluster/model/consensus/GreedyConsensusSpectrum.java
+++ b/src/main/java/org/spectra/cluster/model/consensus/GreedyConsensusSpectrum.java
@@ -10,12 +10,12 @@ import java.util.*;
  * This is a greedy version of the FrankEtAlConsensusSpectrumBuilder. It only supports the addition of spectra but not their removal.
  * Thereby, the original peaks do not have to be kept. This implementation of {@link IConsensusSpectrumBuilder} contains in the
  * allPeaksInCluster property all the peaks of the spectra that belongs to the cluster.
- *
+ * <p>
  * allPeaksInCluster: Contains all the peaks of the {@link IBinarySpectrum} that belong to the Cluster. All peaks of the spectra that belongs to
  * the Cluster needs to be keep to accurately compute the ConsensusPeaks each time is needed.
- *
+ * <p>
  * consensusPeaks: This is the Array of @{@link BinaryPeak} of a clean @{@link GreedyConsensusSpectrum}.
- *
+ * <p>
  * isDirty: This variable is used to notice the algorithm each time the consensusPeaks are generated from the allPeaksInCluster. This variable is important because
  * the class only will update the consensusPeaks when is needed.
  *
@@ -39,7 +39,7 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
     private final String id;
 
     // The peaks of the GreedyConsensusSpectrum
-    private BinaryPeak[]  consensusPeaks;
+    private BinaryPeak[] consensusPeaks;
 
     // All peaks in the Cluster
     private BinaryConsensusPeak[] allPeaksInCluster = new BinaryConsensusPeak[0];
@@ -64,10 +64,11 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
 
     /**
      * Generate a new GreedyConsensusSpectrum
-     * @param id The id to use
-     * @param minPeaksToKeep The minimum number of peaks that should always be retained.
+     *
+     * @param id                   The id to use
+     * @param minPeaksToKeep       The minimum number of peaks that should always be retained.
      * @param peaksPerWindowToKeep The minimum number of peaks to keep within the m/z window size.
-     * @param windowSize The m/z window size for the peak filter to use.
+     * @param windowSize           The m/z window size for the peak filter to use.
      */
     public GreedyConsensusSpectrum(String id, int minPeaksToKeep, int peaksPerWindowToKeep, int windowSize) {
         this.id = id;
@@ -89,7 +90,7 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
 
     /**
      * This function will add to the allPeaksInCluster, the peaks from the newSpectra.
-     *
+     * <p>
      * Any clustering process will compute the similarity between spectra and try to add the similar spectra to the {@link GreedyConsensusSpectrum}.
      * This method only add the peaks of the spetra to allPeaksInCluster and declare the Consensus Spectrum as Dirty. The algorithm loop the list of {@link IBinarySpectrum} and
      * add the {@link BinaryPeak} o the allPeaksInCluster property.
@@ -109,12 +110,12 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
             nSpectra++;
 
             averagePrecursorMz = (int) Math.round(
-                    (double) averagePrecursorMz * ((double) (nSpectra -1) / nSpectra) +
+                    (double) averagePrecursorMz * ((double) (nSpectra - 1) / nSpectra) +
                             (double) spectrum.getPrecursorMz() / nSpectra);
         }
 
-        // update properties charge, precursor m/z and precursor intensity
-        updateProperties();
+        // update the average charge
+        averageCharge = sumCharge / nSpectra;
 
         setIsDirty(true);
     }
@@ -138,8 +139,8 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
 
         nSpectra = totalSpectra;
 
-        // update properties charge, precursor m/z and precursor intensity
-        updateProperties();
+        // update the average charge
+        averageCharge = sumCharge / nSpectra;
 
         setIsDirty(true);
     }
@@ -148,7 +149,7 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
      * Adds the passed peaks to the spectrum.
      *
      * @param existingPeaks The already existing peaks
-     * @param peaksToAdd New peaks to add. These may be BinaryPeak or BinaryConsensusPeak objects.
+     * @param peaksToAdd    New peaks to add. These may be BinaryPeak or BinaryConsensusPeak objects.
      */
     protected static BinaryConsensusPeak[] addPeaksToConsensus(BinaryConsensusPeak[] existingPeaks, BinaryPeak[] peaksToAdd) {
         if (peaksToAdd.length < 1) {
@@ -161,13 +162,13 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
 
         BinaryConsensusPeak[] newPeaks = new BinaryConsensusPeak[existingPeaks.length + peaksToAdd.length];
 
-        while (indexExistingPeaks < existingPeaks.length && indexPeaksToAdd < peaksToAdd.length){
+        while (indexExistingPeaks < existingPeaks.length && indexPeaksToAdd < peaksToAdd.length) {
 
-            if(existingPeaks[indexExistingPeaks].getMz() < peaksToAdd[indexPeaksToAdd].getMz()){
+            if (existingPeaks[indexExistingPeaks].getMz() < peaksToAdd[indexPeaksToAdd].getMz()) {
                 newPeaks[finalPeakIndex] = existingPeaks[indexExistingPeaks];
                 indexExistingPeaks++;
                 finalPeakIndex++;
-            }else if (existingPeaks[indexExistingPeaks].getMz() == peaksToAdd[indexPeaksToAdd].getMz()){
+            } else if (existingPeaks[indexExistingPeaks].getMz() == peaksToAdd[indexPeaksToAdd].getMz()) {
                 // it's the same peak so adapt it
                 int newCount = existingPeaks[indexExistingPeaks].getCount();
                 long newIntensity = existingPeaks[indexExistingPeaks].getIntensity() * existingPeaks[indexExistingPeaks].getCount();
@@ -203,14 +204,14 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
         }
 
         // Add the remaining spectra from existing Peaks
-        while (indexExistingPeaks < existingPeaks.length){
+        while (indexExistingPeaks < existingPeaks.length) {
             newPeaks[finalPeakIndex] = existingPeaks[indexExistingPeaks];
             indexExistingPeaks++;
             finalPeakIndex++;
         }
 
         // Add the remaining spectra from new Peaks
-        while (indexPeaksToAdd < peaksToAdd.length){
+        while (indexPeaksToAdd < peaksToAdd.length) {
             if (peaksToAdd[indexPeaksToAdd] instanceof BinaryConsensusPeak)
                 newPeaks[finalPeakIndex] = new BinaryConsensusPeak((BinaryConsensusPeak) peaksToAdd[indexPeaksToAdd]);
             else
@@ -223,26 +224,12 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
     }
 
     /**
-     * Updates all properties of the consensus spectrum as well as the actual consensus spectrum.
-     * AveragePrecursorMZ and averageCharge.
-     */
-    protected void updateProperties() {
-        if (nSpectra > 0) {
-            averageCharge = sumCharge / nSpectra;
-        } else {
-            averagePrecursorMz = 0;
-            averageCharge = 0;
-        }
-    }
-
-    /**
      * Generate the consensus Spectrum using the Intensities in the allPeaksInCluster.
      * A normalization step is performed in the peaks and only the most intensity peaks
      * in an mz windows are keept . The current implementation combine the functions
      * adaptPeak and the function filterNoise.
-     *
      */
-    private void generateConsensusSpectrum(){
+    private void generateConsensusSpectrum() {
         if (allPeaksInCluster.length < 1) {
             consensusPeaks = new BinaryPeak[0];
         }
@@ -252,75 +239,14 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
     }
 
     /**
-     * Filters the consensus spectrum keeping only the top N peaks per M m/z
-     * @param peaks Peaks to filter
-     * @return final clean array {@link BinaryConsensusPeak}
-     */
-    protected BinaryConsensusPeak[] filterNoise(BinaryConsensusPeak[] peaks) {
-        if (peaks.length < minPeaksToKeep || peaks.length < 1) {
-            return peaks;
-        }
-
-        // get the max m/z
-        int maxMz = Arrays.stream(peaks).mapToInt(BinaryPeak::getMz).max().getAsInt();
-        int peakIndex = 0;
-
-        List<BinaryConsensusPeak> peaksToKeep = new ArrayList<>(100);
-
-        // Keep top N peaks per W m/z
-        for (int windowStart = 0; windowStart <= maxMz && peakIndex < peaks.length; windowStart += windowSize) {
-            List<BinaryConsensusPeak> windowPeaks = new ArrayList<>(20);
-
-            for(; peakIndex < peaks.length && peaks[peakIndex].getMz() < windowStart + windowSize; peakIndex++) {
-                windowPeaks.add(peaks[peakIndex]);
-            }
-
-            if (windowPeaks.size() < 1) {
-                continue;
-            }
-
-            if (windowPeaks.size() <= peaksPerWindowToKeep) {
-                peaksToKeep.addAll(windowPeaks);
-            } else {
-                // only keep the top N peaks
-                windowPeaks.sort(Comparator.comparingInt(BinaryPeak::getIntensity));
-                peaksToKeep.addAll(windowPeaks.subList(windowPeaks.size() - peaksPerWindowToKeep, windowPeaks.size()));
-            }
-        }
-
-        return peaksToKeep.stream().sorted(Comparator.comparingInt(BinaryPeak::getMz)).toArray(BinaryConsensusPeak[]::new);
-    }
-
-    /**
-     * Adapt the peak intensities in allPeaksInCluster using the following formula:
-     * I = I * (0.95 + 0.05 * (1 + pi)^5)
-     * //TOdo : @jgriss where this came from.
-     * where pi is the peaks probability
-     */
-    protected static BinaryConsensusPeak[] adaptPeakIntensities(BinaryConsensusPeak[] peaks, int nSpectra) {
-        BinaryConsensusPeak[] adaptedPeaks = new BinaryConsensusPeak[peaks.length];
-        double doubleSpectra = (double) nSpectra;
-
-        for (int i = 0; i < peaks.length; i++) {
-            double peakProbability = (double) peaks[i].getCount() / doubleSpectra;
-            int newIntensity = (int) Math.round((double) peaks[i].getIntensity() * (0.95 + 0.05 * Math.pow(1 + peakProbability, 5)));
-
-            adaptedPeaks[i] = new BinaryConsensusPeak(peaks[i].getMz(), newIntensity, peaks[i].getCount());
-        }
-
-        return adaptedPeaks;
-    }
-
-    /**
      * Adapt the peak intensities in allPeaksInCluster using the following formula:
      * I = I * (0.95 + 0.05 * (1 + pi)^5) . This probability comes from the FrankEtAll manuscript.
      *
-     *
-     * @param peaks This are all the peaks in the following consensus cluster.
+     * @param peaks    This are all the peaks in the following consensus cluster.
      * @param nSpectra Number of spectra.
      * @return A clean array with {@link BinaryConsensusPeak}
      */
-    protected  BinaryConsensusPeak[] adaptPeakWithNoiseFilterIntensities(BinaryConsensusPeak[] peaks, int nSpectra) {
+    protected BinaryConsensusPeak[] adaptPeakWithNoiseFilterIntensities(BinaryConsensusPeak[] peaks, int nSpectra) {
         BinaryConsensusPeak[] adaptedPeaks = new BinaryConsensusPeak[peaks.length];
 
         double doubleSpectra = (double) nSpectra;
@@ -332,7 +258,7 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
             int newIntensity = (int) Math.round((double) peaks[i].getIntensity() * (0.95 + 0.05 * Math.pow(1 + peakProbability, 5)));
 
             adaptedPeaks[i] = new BinaryConsensusPeak(peaks[i].getMz(), newIntensity, peaks[i].getCount());
-            if(peaks[i].getMz() > maxMz)
+            if (peaks[i].getMz() > maxMz)
                 maxMz = peaks[i].getMz();
         }
 
@@ -345,13 +271,13 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
         /**
          * The maxiumn number of peaks to keep will be, the number of intervals * number of peaks per interval.
          */
-        List<BinaryConsensusPeak> peaksToKeep = new ArrayList<>((maxMz/windowSize) * peaksPerWindowToKeep);
+        List<BinaryConsensusPeak> peaksToKeep = new ArrayList<>((maxMz / windowSize) * peaksPerWindowToKeep);
 
         // Keep top N peaks per W m/z
         for (int windowStart = 0; windowStart <= maxMz && peakIndex < adaptedPeaks.length; windowStart += windowSize) {
-            List<BinaryConsensusPeak> windowPeaks = new ArrayList<>((maxMz/windowSize) * peaksPerWindowToKeep);
+            List<BinaryConsensusPeak> windowPeaks = new ArrayList<>((maxMz / windowSize) * peaksPerWindowToKeep);
 
-            for(; peakIndex < adaptedPeaks.length && adaptedPeaks[peakIndex].getMz() < windowStart + windowSize; peakIndex++) {
+            for (; peakIndex < adaptedPeaks.length && adaptedPeaks[peakIndex].getMz() < windowStart + windowSize; peakIndex++) {
                 windowPeaks.add(adaptedPeaks[peakIndex]);
             }
 
@@ -368,19 +294,20 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
             }
         }
 
-        return peaksToKeep.stream().sorted(Comparator.comparingInt(BinaryPeak::getMz)).toArray(BinaryConsensusPeak[]::new);
-
-
-
+        return peaksToKeep
+                .stream()
+                .sorted(Comparator.comparingInt(BinaryPeak::getMz))
+                .toArray(BinaryConsensusPeak[]::new);
     }
 
     /**
      * This function retrieve the current {@link IBinarySpectrum}.
+     *
      * @return binaryConsensusSpectrum
      */
     @Override
     public IBinarySpectrum getConsensusSpectrum() {
-        if(isDirty)
+        if (isDirty)
             generateConsensusSpectrum();
         return this;
     }
@@ -392,7 +319,8 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
         nSpectra = 0;
 
         allPeaksInCluster = new BinaryConsensusPeak[0];
-        setIsDirty(true);
+        consensusPeaks = new BinaryPeak[0];
+        setIsDirty(false);
     }
 
     @Override
@@ -415,35 +343,31 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
 
     @Override
     public int getPrecursorMz() {
-        if(isDirty())
-            generateConsensusSpectrum();
         return averagePrecursorMz;
     }
 
     @Override
     public int getPrecursorCharge() {
-        if(isDirty())
-            generateConsensusSpectrum();
         return averageCharge;
     }
 
     @Override
     public int[] getCopyMzVector() {
-        if(isDirty())
+        if (isDirty())
             generateConsensusSpectrum();
         return Arrays.stream(consensusPeaks).mapToInt(BinaryPeak::getMz).toArray();
     }
 
     @Override
     public int[] getCopyIntensityVector() {
-        if(isDirty())
+        if (isDirty())
             generateConsensusSpectrum();
         return Arrays.stream(consensusPeaks).mapToInt(BinaryPeak::getIntensity).toArray();
     }
 
     @Override
     public int getNumberOfPeaks() {
-        if(isDirty())
+        if (isDirty())
             generateConsensusSpectrum();
         return consensusPeaks.length;
     }
@@ -455,7 +379,7 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
 
     @Override
     public BinaryPeak[] getPeaks() {
-        if(isDirty())
+        if (isDirty())
             generateConsensusSpectrum();
 
         return consensusPeaks;

--- a/src/main/java/org/spectra/cluster/model/consensus/GreedyConsensusSpectrum.java
+++ b/src/main/java/org/spectra/cluster/model/consensus/GreedyConsensusSpectrum.java
@@ -243,12 +243,12 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
      *
      */
     private void generateConsensusSpectrum(){
-
         if (allPeaksInCluster.length < 1) {
             consensusPeaks = new BinaryPeak[0];
         }
         consensusPeaks = adaptPeakWithNoiseFilterIntensities(allPeaksInCluster, nSpectra);
 
+        setIsDirty(false);
     }
 
     /**
@@ -313,7 +313,7 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
 
     /**
      * Adapt the peak intensities in allPeaksInCluster using the following formula:
-     * I = I * (0.95 + 0.05 * (1 + pi)^5) . This probability cames from the FrankEtAll manuscript.
+     * I = I * (0.95 + 0.05 * (1 + pi)^5) . This probability comes from the FrankEtAll manuscript.
      *
      *
      * @param peaks This are all the peaks in the following consensus cluster.
@@ -321,7 +321,6 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
      * @return A clean array with {@link BinaryConsensusPeak}
      */
     protected  BinaryConsensusPeak[] adaptPeakWithNoiseFilterIntensities(BinaryConsensusPeak[] peaks, int nSpectra) {
-
         BinaryConsensusPeak[] adaptedPeaks = new BinaryConsensusPeak[peaks.length];
 
         double doubleSpectra = (double) nSpectra;

--- a/src/main/java/org/spectra/cluster/tools/CliOptions.java
+++ b/src/main/java/org/spectra/cluster/tools/CliOptions.java
@@ -17,8 +17,6 @@ public class CliOptions {
         CONFIG_FILE("config", "c"),
         OUTPUT_PATH("output.path", "o"),
 
-        INPUT_FILES("input.files", "i"),
-
         PRECURSOR_TOLERANCE("precursor.tolerance", "p"),
         FRAGMENT_TOLERANCE("fragment.tolerance", "f"),
 
@@ -79,13 +77,6 @@ public class CliOptions {
                 .withLongOpt(OPTIONS.CONFIG_FILE.getLongValue())
                 .create(OPTIONS.CONFIG_FILE.getValue());
         options.addOption(config);
-
-        Option inputFiles = OptionBuilder
-                .hasArgs(5)
-                .withDescription("Input files to be analyzed. If more than one file is provided it should be with space ")
-                .withLongOpt(OPTIONS.INPUT_FILES.getLongValue())
-                .create(OPTIONS.INPUT_FILES.getValue());
-        options.addOption(inputFiles);
 
         Option fragmentTolerance = OptionBuilder
                 .hasArg()
@@ -189,7 +180,7 @@ public class CliOptions {
          * ADVANCED OPTIONS
          */
         Option xMinComparisons = OptionBuilder
-                .withDescription("(Experimental option) Sets the minimum number of comparisons used to calculate the probability that incorrect spectra are clustered.")
+                .withDescription("(Experimental option) Sets the minimum number of comparisons used to calculate the probability that incorrect spectra are clustered. This number is derived from the data and the set value used as a minimum.")
                 .hasArg()
                 .withLongOpt(OPTIONS.ADVANCED_MIN_NUMBER_COMPARISONS.getLongValue())
                 .create(OPTIONS.ADVANCED_MIN_NUMBER_COMPARISONS.getValue());

--- a/src/main/java/org/spectra/cluster/tools/SpectraClusterTool.java
+++ b/src/main/java/org/spectra/cluster/tools/SpectraClusterTool.java
@@ -1,5 +1,6 @@
 package org.spectra.cluster.tools;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -42,6 +43,7 @@ import java.util.*;
  *
  * @author ypriverol on 18/10/2018.
  */
+@Slf4j
 public class SpectraClusterTool implements IProgressListener {
 
     public static final boolean DELETE_TEMPORARY_CLUSTERING_RESULTS = true;
@@ -152,6 +154,7 @@ public class SpectraClusterTool implements IProgressListener {
 
             List<IBinarySpectrum> spectra = new ArrayList<>(1_000);
 
+            log.debug(String.format("Loading spectra from %d file(s)...", inputFiles.length));
             while (iterator.hasNext()) {
                 spectra.add(iterator.next());
             }
@@ -166,6 +169,7 @@ public class SpectraClusterTool implements IProgressListener {
                     startThreshold, endThreshold, rounds, new CombinedFisherIntensityTest(),
                     new MinNumberComparisonsAssessor(10_000), nInitiallySharedPeaks);
 
+            log.debug("Clustering files...");
             ICluster[] clusters = engine.clusterSpectra(spectra.toArray(new IBinarySpectrum[0]));
 
             IClusterWriter writer = new DotClusteringWriter(thisResult, false, localStorage);
@@ -174,7 +178,7 @@ public class SpectraClusterTool implements IProgressListener {
 
             System.out.println("Results written to " + thisResult.toString());
 
-
+            System.exit(0);
         } catch (MissingParameterException e) {
             System.out.println("Error: " + e.getMessage() + "\n\n");
             printUsage();

--- a/src/main/java/org/spectra/cluster/util/DefaultParameters.java
+++ b/src/main/java/org/spectra/cluster/util/DefaultParameters.java
@@ -32,6 +32,7 @@ public class DefaultParameters {
     private Float thresholdStart;
     private Float thresholdEnd;
     private int nInitiallySharedPeaks;
+    private int minNumberOfComparisons;
 
 
     public DefaultParameters(){
@@ -69,6 +70,8 @@ public class DefaultParameters {
             this.filterReportPeaks = Boolean.parseBoolean(properties.getProperty("filters.remove.reporter.peaks"));
         if(properties.containsKey("initially.shared.peaks"))
             this.nInitiallySharedPeaks = Integer.parseInt(properties.getProperty("initially.shared.peaks"));
+        if(properties.contains("x.min.comparisons"))
+            this.minNumberOfComparisons = Integer.parseInt(properties.getProperty("x.min.comparisons"));
     }
 
     public Properties readProperties() throws URISyntaxException {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,20 @@
-precursor.tolerance=0.5
+precursor.tolerance=1
 fragment.tolerance=0.5
 
 
 # Clustering execution parameters
-threshold.start=0.999F
-threshold.end=0.999F
-cluster.rounds=10
+threshold.start=1.0F
+threshold.end=0.99F
+cluster.rounds=5
 binary.temp.directory=/tmp/
 reuse.binary.files=false
-cluster.fast.mode=true
+cluster.fast.mode=false
 
 # Number of peaks that will be used to perform the comparison
 number.higher.peaks=40
 initially.shared.peaks=5
 filters.remove.reporter.peaks=true
+
+# The minimum number of comparisons is derived from the data. The set number
+# is used as an additional minimum
+x.min.comparisons=0

--- a/src/test/java/org/spectra/cluster/cdf/SpectraPerBinNumberComparisonAssessorTest.java
+++ b/src/test/java/org/spectra/cluster/cdf/SpectraPerBinNumberComparisonAssessorTest.java
@@ -2,6 +2,17 @@ package org.spectra.cluster.cdf;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.spectra.cluster.filter.binaryspectrum.HighestPeakPerBinFunction;
+import org.spectra.cluster.filter.rawpeaks.*;
+import org.spectra.cluster.io.MzSpectraReaderTest;
+import org.spectra.cluster.io.spectra.MzSpectraReader;
+import org.spectra.cluster.model.spectra.IBinarySpectrum;
+import org.spectra.cluster.normalizer.BasicIntegerNormalizer;
+import org.spectra.cluster.normalizer.MaxPeakNormalizer;
+import org.spectra.cluster.normalizer.TideBinner;
+
+import java.io.File;
+import java.util.Iterator;
 
 public class SpectraPerBinNumberComparisonAssessorTest {
     @Test
@@ -22,5 +33,36 @@ public class SpectraPerBinNumberComparisonAssessorTest {
         Assert.assertEquals(100, assessor.getNumberOfComparisons(20, 1));
         Assert.assertEquals(50, assessor.getNumberOfComparisons(30, 1));
         Assert.assertEquals(50, assessor.getNumberOfComparisons(40, 1));
+    }
+
+    @Test
+    public void testLoadingFiles() throws Exception {
+        File testFile = new File(MzSpectraReaderTest.class.getClassLoader().getResource("same_sequence_cluster.mgf").toURI());
+
+        BasicIntegerNormalizer normalizer = new BasicIntegerNormalizer();
+
+        IRawSpectrumFunction loadingFilter = new RemoveImpossiblyHighPeaksFunction()
+                .specAndThen(new RemovePrecursorPeaksFunction(0.5))
+                .specAndThen(new RawPeaksWrapperFunction(new KeepNHighestRawPeaks(40)));
+
+        MzSpectraReader reader = new MzSpectraReader( new TideBinner(), new MaxPeakNormalizer(),
+                normalizer, new HighestPeakPerBinFunction(), loadingFilter, testFile);
+
+        SpectraPerBinNumberComparisonAssessor assessor = new SpectraPerBinNumberComparisonAssessor(
+                (int) Math.round(BasicIntegerNormalizer.MZ_CONSTANT * 0.5), 0, 2500 * BasicIntegerNormalizer.MZ_CONSTANT);
+
+        reader.addSpectrumListener(assessor);
+
+        Iterator<IBinarySpectrum> it = reader.readBinarySpectraIterator();
+
+        while (it.hasNext()) {
+            Assert.assertNotNull(it.next());
+        }
+
+        // make sure all spectra were counted
+        Assert.assertEquals(54, assessor.getNumberOfComparisons(normalizer.binValue(977.0), 0));
+        Assert.assertEquals(38, assessor.getNumberOfComparisons(normalizer.binValue(652.0), 0));
+        Assert.assertEquals(1, assessor.getNumberOfComparisons(normalizer.binValue(651.0), 0));
+        Assert.assertEquals(66, assessor.getNumberOfComparisons(normalizer.binValue(651.69), 0));
     }
 }

--- a/src/test/java/org/spectra/cluster/model/consensus/GreedyConsensusSpectrumTest.java
+++ b/src/test/java/org/spectra/cluster/model/consensus/GreedyConsensusSpectrumTest.java
@@ -88,57 +88,6 @@ public class GreedyConsensusSpectrumTest {
         Assert.assertEquals(10, mergedPeaks[4].getCount());
     }
 
-    @Test
-    public void testAdaptPeakIntensities() {
-        BinaryConsensusPeak[] existingPeaks = {
-                new BinaryConsensusPeak(10, 100, 10),
-                new BinaryConsensusPeak(20, 200, 5),
-                new BinaryConsensusPeak(100, 1000, 30)
-        };
-
-        BinaryConsensusPeak[] adaptedPeaks = GreedyConsensusSpectrum.adaptPeakIntensities(existingPeaks, 30);
-
-        Assert.assertEquals(3, adaptedPeaks.length);
-
-        for (int i = 0; i < existingPeaks.length; i++) {
-            Assert.assertEquals(existingPeaks[i].getMz(), adaptedPeaks[i].getMz());
-            Assert.assertEquals(existingPeaks[i].getCount(), adaptedPeaks[i].getCount());
-        }
-
-        Assert.assertEquals(116, adaptedPeaks[0].getIntensity());
-            Assert.assertEquals(212, adaptedPeaks[1].getIntensity());
-        Assert.assertEquals(2550, adaptedPeaks[2].getIntensity());
-    }
-
-    @Test
-    public void tesFilterNoise() {
-        BinaryConsensusPeak[] existingPeaks = {
-                new BinaryConsensusPeak(10, 100, 10),
-                new BinaryConsensusPeak(20, 200, 5),
-                new BinaryConsensusPeak(100, 1000, 30),
-                new BinaryConsensusPeak(110, 1000, 30),
-                new BinaryConsensusPeak(120, 10, 30),
-                new BinaryConsensusPeak(130, 100, 30),
-                new BinaryConsensusPeak(140, 100, 30),
-                new BinaryConsensusPeak(150, 1000, 30),
-                new BinaryConsensusPeak(160, 1000, 30),
-                new BinaryConsensusPeak(170, 1000, 30),
-                new BinaryConsensusPeak(180, 200, 30),
-                new BinaryConsensusPeak(1000, 200, 30)
-        };
-
-        GreedyConsensusSpectrum consensusSpectrum = new GreedyConsensusSpectrum("0", 0, 5, 100);
-        BinaryConsensusPeak[] filtered = consensusSpectrum.filterNoise(existingPeaks);
-
-        int[] expectedMz = {10, 20, 100, 110, 150, 160, 170, 1000};
-
-        Assert.assertEquals(expectedMz.length, filtered.length);
-
-        for (int i = 0; i < expectedMz.length; i++) {
-            Assert.assertEquals(expectedMz[i], filtered[i].getMz());
-        }
-    }
-
     /**
      * Tests whether the consensus spectrum of the first 10 test spectra (all from the same peptide) are similar to the consensus.
      * @throws Exception

--- a/src/test/java/org/spectra/cluster/tools/SpectraClusterToolTest.java
+++ b/src/test/java/org/spectra/cluster/tools/SpectraClusterToolTest.java
@@ -1,0 +1,28 @@
+package org.spectra.cluster.tools;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class SpectraClusterToolTest {
+    @Ignore
+    @Test
+    public void testLocalBenchmark() throws Exception {
+        // create the args
+        String[] args = {
+              "-o", "/tmp/test.clustering",
+              "-p", "1", // precursor tolerance
+              "-f", "0.5", // fragment tolerance
+              "-mc", "0", // minimum comparisons (auto)
+              "-s", "1", // start threshold
+              "-e", "0.99", // end-threshold
+              "-r", "5", // rounds
+              "/home/jg/Projects/Testfiles/melanoma_heterogeneity/Melanom_metastasen_Griss_P-B_1_151120061620.fdr01.msgf.mgf",
+                "/home/jg/Projects/Testfiles/melanoma_heterogeneity/Melanom_metastasen_Griss_P-B_2_151120164543.fdr01.msgf.mgf",
+                "/home/jg/Projects/Testfiles/melanoma_heterogeneity/Melanom_metastasen_Griss_P-B_3_151121034515.fdr01.msgf.mgf",
+                "/home/jg/Projects/Testfiles/melanoma_heterogeneity/Melanom_metastasen_Griss_P-B_4_151121141440.fdr01.msgf.mgf"
+        };
+
+        // start the clustering
+        SpectraClusterTool.main(args);
+    }
+}


### PR DESCRIPTION
  * Adapted CLI to only use the threshold set on the command line
  * Adapted CLI to use the output filename without any changes
  * Adapted CLI to use the SpectraPerBinComparison assessor and evaluate the x.min.comparisons parameter correclty
  * Added jgitflow to POM file
  * Removed `input.files` parameter and adapted code to evaluate all additional parameters as input files - this makes it easier to use with large datasets (ie. `java -jar spectra-cluster-2.jar -output test.clustering *.mgf`)
  * Fixes performance issues (see #60) - now performance is comparable to old code in a very small test dataset
  * Removed unused code from GreedyConsensusSpectrum
  * Adapted StreamIteratorConverter to remove invalid spectra. 