### PR TITLE
Optimised Kendall Tau correlation

### DIFF
--- a/src/main/java/org/spectra/cluster/filter/binaryspectrum/FractionTicFilterFunction.java
+++ b/src/main/java/org/spectra/cluster/filter/binaryspectrum/FractionTicFilterFunction.java
@@ -49,7 +49,9 @@ public class FractionTicFilterFunction implements IBinarySpectrumFunction {
         Arrays.sort(peaklist, Comparator.comparingInt(BinaryPeak::getIntensity).reversed());
 
         // get the total intensity
-        double totalIntensity = Arrays.stream(peaklist).mapToInt(BinaryPeak::getIntensity).sum();
+        double totalIntensity = 0;
+        for (int i = 0; i < peaklist.length; i++)
+            totalIntensity += peaklist[i].getIntensity();
 
         BinaryPeak[] filteredPeaks = new BinaryPeak[peaklist.length];
         int filteredPeaksSize = 0;

--- a/src/main/java/org/spectra/cluster/similarity/CombinedFisherIntensityTest.java
+++ b/src/main/java/org/spectra/cluster/similarity/CombinedFisherIntensityTest.java
@@ -17,11 +17,39 @@ import java.util.List;
 public class CombinedFisherIntensityTest implements IBinarySpectrumSimilarity {
 
     private final KendallsCorrelation kendallsCorrelation = new KendallsCorrelation();
+    /** Cached ChiSquareDistribution for the HGT score calculation */
     protected final ChiSquaredDistribution chiSquaredDistribution = new ChiSquaredDistribution(4); // always 4 degrees of freedom
-
+    /** Static RandomEngine since it is not used */
     protected final static RandomEngine RANDOM_ENGINE = RandomEngine.makeDefault();
-
+    /** Define a maximum score which is returned if infinity is reached */
     public static final double MAX_SCORE = 200;
+    /** Value for an extremely low score */
+    public static final double BAD_SCORE = 0;
+
+    /** Minimum number of shared peaks required to calculate the score. Otherwise BAD_SCORE is returned */
+    private final int minSharedPeaks;
+    /** Maximum hgt probability above which no Kendall correlation is calculated */
+    private final double maxHgt;
+
+    /**
+     * Create a new CombinedFisherIntensityTest similarity function.
+     * @param minSharedPeaks The minimum number of shared peaks to calculate the score.
+     * @param maxHgt The maximum allowed p-value for the HGT test. If the HGT score is above this
+     *               p-value, the Kendall correlation is not calculated and only the HGT score returned
+     */
+    public CombinedFisherIntensityTest(int minSharedPeaks, double maxHgt) {
+        // minSharedPeaks must not be below 1
+        this.minSharedPeaks = (minSharedPeaks >= 1 ? minSharedPeaks : 1);
+        this.maxHgt = maxHgt;
+    }
+
+    /**
+     * Creates a CombinedFisherIntensityTest with disabled additional filtering
+     */
+    public CombinedFisherIntensityTest() {
+        this.minSharedPeaks = 1;
+        this.maxHgt = 2; // impossibly high
+    }
 
     @Override
     public double correlation(IBinarySpectrum spectrum1, IBinarySpectrum spectrum2) {
@@ -56,8 +84,8 @@ public class CombinedFisherIntensityTest implements IBinarySpectrumSimilarity {
         }
 
         // return 0 if no intensities are shared
-        if (sharedIntensitySpec1.size() < 1) {
-            return 0;
+        if (sharedIntensitySpec1.size() < minSharedPeaks) {
+            return BAD_SCORE;
         }
 
         // calculate the hypergeometric score
@@ -80,6 +108,11 @@ public class CombinedFisherIntensityTest implements IBinarySpectrumSimilarity {
 
         if (hgtScore == 0) {
             hgtScore = 1;
+        }
+
+        // only return the hgtScore if it is above the allowed maximum
+        if (hgtScore > maxHgt) {
+            return -Math.log(hgtScore);
         }
 
         // calculate the fisher p

--- a/src/main/java/org/spectra/cluster/similarity/IntPair.java
+++ b/src/main/java/org/spectra/cluster/similarity/IntPair.java
@@ -1,0 +1,9 @@
+package org.spectra.cluster.similarity;
+
+import lombok.Data;
+
+@Data
+public class IntPair {
+    private final int first;
+    private final int second;
+}

--- a/src/main/java/org/spectra/cluster/tools/SpectraClusterTool.java
+++ b/src/main/java/org/spectra/cluster/tools/SpectraClusterTool.java
@@ -5,7 +5,6 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.PosixParser;
-import org.spectra.cluster.cdf.MinNumberComparisonsAssessor;
 import org.spectra.cluster.cdf.SpectraPerBinNumberComparisonAssessor;
 import org.spectra.cluster.engine.GreedyClusteringEngine;
 import org.spectra.cluster.engine.IClusteringEngine;
@@ -175,7 +174,7 @@ public class SpectraClusterTool implements IProgressListener {
             IClusteringEngine engine = new GreedyClusteringEngine(
                     binnedPrecursorTolerance,
                     startThreshold, endThreshold, rounds, new CombinedFisherIntensityTest(),
-                    new MinNumberComparisonsAssessor(10_000), nInitiallySharedPeaks);
+                    numberOfComparisonAssessor, nInitiallySharedPeaks);
 
             log.debug("Clustering files...");
             ICluster[] clusters = engine.clusterSpectra(spectra.toArray(new IBinarySpectrum[0]));

--- a/src/test/java/org/spectra/cluster/similarity/CombinedFisherIntensityTestTest.java
+++ b/src/test/java/org/spectra/cluster/similarity/CombinedFisherIntensityTestTest.java
@@ -4,6 +4,7 @@ import cern.jet.random.HyperGeometric;
 import cern.jet.random.engine.RandomEngine;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.spectra.cluster.cdf.MinNumberComparisonsAssessor;
 import org.spectra.cluster.engine.GreedyClusteringEngine;
@@ -140,5 +141,20 @@ public class CombinedFisherIntensityTestTest {
         ICluster[] clusters = engine.clusterSpectra(impSpectra.toArray(new IBinarySpectrum[0]));
 
         Assert.assertEquals(1, clusters.length);
+    }
+
+    @Test
+    @Ignore
+    public void testScoreBenchmark() throws Exception {
+        IBinarySpectrumSimilarity similarity = new CombinedFisherIntensityTest();
+
+        for (int rounds = 0; rounds < 1000_000; rounds++) {
+            for (int j = 0; j < impSpectra.size(); j++) {
+                for (int i = 1; i < impSpectra.size(); i++) {
+                    double score = similarity.correlation(impSpectra.get(j), impSpectra.get(i));
+                    Assert.assertNotNull(score);
+                }
+            }
+        }
     }
 }

--- a/src/test/java/org/spectra/cluster/similarity/CombinedFisherIntensityTestTest.java
+++ b/src/test/java/org/spectra/cluster/similarity/CombinedFisherIntensityTestTest.java
@@ -30,6 +30,8 @@ import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -175,10 +177,11 @@ public class CombinedFisherIntensityTestTest {
 
     @Test
     @Ignore
-    public void testScoreBenchmark() throws Exception {
+    public void testScoreBenchmark() {
         IBinarySpectrumSimilarity similarity = new CombinedFisherIntensityTest();
+        LocalDateTime start = LocalDateTime.now();
 
-        for (int rounds = 0; rounds < 1000_000; rounds++) {
+        for (int rounds = 0; rounds < 100000; rounds++) {
             for (int j = 0; j < impSpectra.size(); j++) {
                 for (int i = 1; i < impSpectra.size(); i++) {
                     double score = similarity.correlation(impSpectra.get(j), impSpectra.get(i));
@@ -186,5 +189,7 @@ public class CombinedFisherIntensityTestTest {
                 }
             }
         }
+
+        System.out.println(String.format("Took %d seconds", Duration.between(start, LocalDateTime.now()).getSeconds()));
     }
 }

--- a/src/test/java/org/spectra/cluster/similarity/KendallsCorrelationTest.java
+++ b/src/test/java/org/spectra/cluster/similarity/KendallsCorrelationTest.java
@@ -50,26 +50,23 @@ public class KendallsCorrelationTest {
             }
 
             // create the list of integers
-            int[] intens1 = new int[nPeaks];
-            int[] intens2 = new int[nPeaks];
-
             List<Double> allIntens1 = new ArrayList<>(s1.getPeakList().values());
             List<Double> allIntens2 = new ArrayList<>(s2.getPeakList().values());
 
             double[] doubles1 = new double[nPeaks];
             double[] doubles2 = new double[nPeaks];
+            IntPair[] pairs = new IntPair[nPeaks];
 
             for (int j = 0; j < nPeaks; j++) {
                 doubles1[j] = Math.round(allIntens1.get(j));
-                intens1[j] = (int) Math.round(allIntens1.get(j));
-
                 doubles2[j] = Math.round(allIntens2.get(j));
-                intens2[j] = (int) Math.round(allIntens2.get(j));
+
+                pairs[j] = new IntPair((int) Math.round(allIntens1.get(j)), (int) Math.round(allIntens2.get(j)));
             }
 
             // compare the taus
             double kOrg = orgKendall.correlation(doubles1, doubles2);
-            double kNew = myKendall.correlation(intens1, intens2);
+            double kNew = myKendall.correlation(pairs);
 
             Assert.assertEquals(kOrg, kNew, 0.0000001);
 


### PR DESCRIPTION
Main changes are:
  * All variables moved from long to int (since we never require long space)
  * Pairs of integers created only once. In the old implementation this was done twice

Other optimisations I tested, including not computing ties anymore actually didn't improve the performance at all. Also here, the improvements are very small. Nevertheless, since it does optimize the code a bit I'd suggest to leave them.