### PR TITLE
Optimised comparison predicate and added charge state filter

### DIFF
--- a/src/main/java/org/spectra/cluster/engine/GreedyClusteringEngine.java
+++ b/src/main/java/org/spectra/cluster/engine/GreedyClusteringEngine.java
@@ -12,7 +12,6 @@ import org.spectra.cluster.model.consensus.GreedyConsensusSpectrum;
 import org.spectra.cluster.model.spectra.IBinarySpectrum;
 import org.spectra.cluster.predicates.ClusterIsKnownComparisonPredicate;
 import org.spectra.cluster.predicates.IComparisonPredicate;
-import org.spectra.cluster.predicates.ShareHighestPeaksClusterPredicate;
 import org.spectra.cluster.similarity.CombinedFisherIntensityTest;
 import org.spectra.cluster.similarity.IBinarySpectrumSimilarity;
 
@@ -52,12 +51,14 @@ public class GreedyClusteringEngine implements IClusteringEngine {
      * @param clusteringRounds The number of clustering rounds to perform.
      * @param similarityMeasure The similarity measure to use
      * @param numberOfComparisonAssessor The numberOfComparisonAssessor to use during the clustering process.
-     * @param nInitiallySharedPeaks Number of highest peaks of which spectra have to share one to be compared.
+     * @param firstRoundPredicate Predicate to use in the first clustering round to decide whether spectra should be compare.
+     *                            In subsequent rounds only spectra that were compared previously are taken into consideration.
      * @throws Exception Thrown in case no CDF can be loaded for the passed similarity measure.
      */
     public GreedyClusteringEngine(int precursorTolerance, float thresholdStart, float thresholdEnd,
                                   int clusteringRounds, IBinarySpectrumSimilarity similarityMeasure,
-                                  INumberOfComparisonAssessor numberOfComparisonAssessor, int nInitiallySharedPeaks)
+                                  INumberOfComparisonAssessor numberOfComparisonAssessor,
+                                  IComparisonPredicate<ICluster> firstRoundPredicate)
             throws Exception {
         this.precursorTolerance = precursorTolerance;
         this.thresholdStart = 1 - thresholdStart;
@@ -65,7 +66,7 @@ public class GreedyClusteringEngine implements IClusteringEngine {
         this.clusteringRounds = clusteringRounds;
         this.similarityMeasure = similarityMeasure;
         this.numberOfComparisonAssessor = numberOfComparisonAssessor;
-        this.firstRoundPredicate = new ShareHighestPeaksClusterPredicate(nInitiallySharedPeaks);
+        this.firstRoundPredicate = firstRoundPredicate;
 
         // some sanity checks
         if (thresholdEnd > thresholdStart) {

--- a/src/main/java/org/spectra/cluster/model/consensus/GreedyConsensusSpectrum.java
+++ b/src/main/java/org/spectra/cluster/model/consensus/GreedyConsensusSpectrum.java
@@ -1,6 +1,7 @@
 package org.spectra.cluster.model.consensus;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.math3.util.FastMath;
 import org.spectra.cluster.filter.binaryspectrum.IBinarySpectrumFunction;
 import org.spectra.cluster.model.spectra.BinaryPeak;
 import org.spectra.cluster.model.spectra.BinarySpectrum;
@@ -126,7 +127,7 @@ public class GreedyConsensusSpectrum implements IConsensusSpectrumBuilder {
         }
 
         // update the average charge
-        averageCharge = sumCharge / nSpectra;
+        averageCharge = FastMath.round(sumCharge / (float) nSpectra);
 
         setIsDirty(true);
     }

--- a/src/main/java/org/spectra/cluster/predicates/SameChargePredicate.java
+++ b/src/main/java/org/spectra/cluster/predicates/SameChargePredicate.java
@@ -1,0 +1,16 @@
+package org.spectra.cluster.predicates;
+
+import org.spectra.cluster.model.cluster.ICluster;
+
+/**
+ * Predicate to test whether two cluster's consensus spectra
+ * have the same charge state.
+ *
+ * @author jg
+ */
+public class SameChargePredicate implements IComparisonPredicate<ICluster> {
+    @Override
+    public boolean test(ICluster o1, ICluster o2) {
+        return o1.getConsensusSpectrum().getPrecursorCharge() == o2.getConsensusSpectrum().getPrecursorCharge();
+    }
+}

--- a/src/main/java/org/spectra/cluster/tools/CliOptions.java
+++ b/src/main/java/org/spectra/cluster/tools/CliOptions.java
@@ -33,6 +33,8 @@ public class CliOptions {
         REUSE_BINARY_FILES("reuse.binary.files", "u"),
         REMOVE_REPORTER_PEAKS("remove.reporters", "rr"),
 
+        IGNORE_CHARGE("ignore.charge", "ic"),
+
         FAST_MODE("fast_mode", "fm"),
         FILTER("filter", "ft"),
         HELP("help", "h"),
@@ -145,6 +147,12 @@ public class CliOptions {
                 .withLongOpt(OPTIONS.REUSE_BINARY_FILES.getLongValue())
                 .create(OPTIONS.REUSE_BINARY_FILES.getValue());
         options.addOption(reuseBinaryFiles);
+
+        Option ignoreCharge = OptionBuilder
+                .withDescription("If set, the spectra's charge state is ignored")
+                .withLongOpt(OPTIONS.IGNORE_CHARGE.getLongValue())
+                .create(OPTIONS.IGNORE_CHARGE.getValue());
+        options.addOption(ignoreCharge);
 
         Option fastMode = OptionBuilder
                 .withDescription("If this option is set the 'fast mode' is enabled. In this mode, the radical peak filtering used for the comparison function is already applied during spectrum conversion. Thereby, the clustering and consensus spectrum quality is slightly decreased but speed increases 2-3 fold.")

--- a/src/main/java/org/spectra/cluster/util/DefaultParameters.java
+++ b/src/main/java/org/spectra/cluster/util/DefaultParameters.java
@@ -31,6 +31,7 @@ public class DefaultParameters {
     private Integer numberHigherPeaks;
     private Double precursorIonTolerance;
     private Double fragmentIonTolerance;
+    private boolean ignoreCharge;
 
     private Float thresholdStart;
     private Float thresholdEnd;
@@ -67,6 +68,8 @@ public class DefaultParameters {
             this.binaryDirectory = properties.getProperty("binary.temp.directory");
         if(properties.containsKey("reuse.binary.files"))
             this.reuseBinary = Boolean.parseBoolean(properties.getProperty("reuse.binary.files"));
+        if(properties.contains("ignore.charge"))
+            this.ignoreCharge = Boolean.parseBoolean(properties.getProperty("ignore.charge"));
         if(properties.containsKey("cluster.fast.mode"))
             this.fastMode = Boolean.parseBoolean(properties.getProperty("cluster.fast.mode"));
         if(properties.containsKey("filters.remove.reporter.peaks"))

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,7 @@ cluster.rounds=5
 binary.temp.directory=/tmp/
 reuse.binary.files=false
 cluster.fast.mode=false
+ignore.charge=false
 
 # Number of peaks that will be used to perform the comparison
 number.higher.peaks=40

--- a/src/test/java/org/spectra/cluster/engine/GreedyClusteringEngineTest.java
+++ b/src/test/java/org/spectra/cluster/engine/GreedyClusteringEngineTest.java
@@ -16,6 +16,7 @@ import org.spectra.cluster.model.spectra.IBinarySpectrum;
 import org.spectra.cluster.normalizer.BasicIntegerNormalizer;
 import org.spectra.cluster.normalizer.MaxPeakNormalizer;
 import org.spectra.cluster.normalizer.TideBinner;
+import org.spectra.cluster.predicates.ShareHighestPeaksClusterPredicate;
 import org.spectra.cluster.similarity.CombinedFisherIntensityTest;
 
 import java.io.File;
@@ -105,7 +106,7 @@ public class GreedyClusteringEngineTest {
     public void testClustering() throws Exception {
         IClusteringEngine engine = new GreedyClusteringEngine(BasicIntegerNormalizer.MZ_CONSTANT,
                 1, 0.99f, 5, new CombinedFisherIntensityTest(),
-                new MinNumberComparisonsAssessor(10000), 5);
+                new MinNumberComparisonsAssessor(10000), new ShareHighestPeaksClusterPredicate(5));
 
         ICluster[] clusters = engine.clusterSpectra(spectra.toArray(new IBinarySpectrum[0]));
 
@@ -232,7 +233,7 @@ public class GreedyClusteringEngineTest {
         // cluster everything
         IClusteringEngine engine = new GreedyClusteringEngine(BasicIntegerNormalizer.MZ_CONSTANT,
                 1, 0.99f, 5, new CombinedFisherIntensityTest(),
-                new MinNumberComparisonsAssessor(10_000), 5);
+                new MinNumberComparisonsAssessor(10_000), new ShareHighestPeaksClusterPredicate(5));
 
         ICluster[] clusters = engine.clusterSpectra(spectra.toArray(new IBinarySpectrum[0]));
 
@@ -268,7 +269,7 @@ public class GreedyClusteringEngineTest {
 
             IClusteringEngine engine = new GreedyClusteringEngine(BasicIntegerNormalizer.MZ_CONSTANT,
                     1, t, 5, new CombinedFisherIntensityTest(),
-                    new MinNumberComparisonsAssessor(10_000), 5);
+                    new MinNumberComparisonsAssessor(10_000), new ShareHighestPeaksClusterPredicate(5));
 
             ICluster[] clusters = engine.clusterSpectra(spectra.toArray(new IBinarySpectrum[0]));
 

--- a/src/test/java/org/spectra/cluster/io/DotClusteringWriterTest.java
+++ b/src/test/java/org/spectra/cluster/io/DotClusteringWriterTest.java
@@ -13,6 +13,7 @@ import org.spectra.cluster.io.properties.InMemoryPropertyStorage;
 import org.spectra.cluster.io.spectra.MzSpectraReader;
 import org.spectra.cluster.model.cluster.ICluster;
 import org.spectra.cluster.model.spectra.IBinarySpectrum;
+import org.spectra.cluster.predicates.ShareHighestPeaksClusterPredicate;
 import org.spectra.cluster.similarity.CombinedFisherIntensityTest;
 
 import java.io.File;
@@ -43,7 +44,7 @@ public class DotClusteringWriterTest {
 
     @Test
     public void testWritingClustering() throws Exception {
-        IClusteringEngine engine = new GreedyClusteringEngine(10_000, 1, 0.99f, 5, new CombinedFisherIntensityTest(), new MinNumberComparisonsAssessor(10000), 5);
+        IClusteringEngine engine = new GreedyClusteringEngine(10_000, 1, 0.99f, 5, new CombinedFisherIntensityTest(), new MinNumberComparisonsAssessor(10000), new ShareHighestPeaksClusterPredicate(5));
 
         ICluster[] clusters = engine.clusterSpectra(spectra.toArray(new IBinarySpectrum[0]));
 

--- a/src/test/java/org/spectra/cluster/io/cluster/BinaryClusterStorageTest.java
+++ b/src/test/java/org/spectra/cluster/io/cluster/BinaryClusterStorageTest.java
@@ -15,6 +15,7 @@ import org.spectra.cluster.model.spectra.IBinarySpectrum;
 import org.spectra.cluster.normalizer.BasicIntegerNormalizer;
 import org.spectra.cluster.normalizer.MaxPeakNormalizer;
 import org.spectra.cluster.normalizer.TideBinner;
+import org.spectra.cluster.predicates.ShareHighestPeaksClusterPredicate;
 import org.spectra.cluster.similarity.CombinedFisherIntensityTest;
 
 import java.io.File;
@@ -65,7 +66,7 @@ public class BinaryClusterStorageTest {
 
         IClusteringEngine engine = new GreedyClusteringEngine(BasicIntegerNormalizer.MZ_CONSTANT,
                 1, 0.99f, 5, new CombinedFisherIntensityTest(),
-                new MinNumberComparisonsAssessor(10000), 5);
+                new MinNumberComparisonsAssessor(10000), new ShareHighestPeaksClusterPredicate(5));
 
         clusters = engine.clusterSpectra(spectra.toArray(new IBinarySpectrum[0]));
     }

--- a/src/test/java/org/spectra/cluster/model/consensus/GreedyConsensusSpectrumTest.java
+++ b/src/test/java/org/spectra/cluster/model/consensus/GreedyConsensusSpectrumTest.java
@@ -286,4 +286,27 @@ public class GreedyConsensusSpectrumTest {
         consensusSpectrum.addConsensusSpectrum(consensusSpectrum2);
         Assert.assertEquals(precursorMz, consensusSpectrum.getPrecursorMz());
     }
+
+    @Test
+    public void testAverageChargeApproach() {
+        int sumCharge = 10;
+        int nSpectra = 5;
+
+        Assert.assertEquals(2, Math.round(sumCharge / (float) nSpectra));
+
+        sumCharge += 1;
+        nSpectra++;
+
+        Assert.assertEquals(2, Math.round(sumCharge / (float) nSpectra));
+
+        sumCharge = 5;
+        nSpectra = 5;
+
+        Assert.assertEquals(1, Math.round(sumCharge / (float) nSpectra));
+
+        nSpectra++;
+        sumCharge += 2;
+
+        Assert.assertEquals(1, Math.round(sumCharge / (float) nSpectra));
+    }
 }

--- a/src/test/java/org/spectra/cluster/similarity/CombinedFisherIntensityTestTest.java
+++ b/src/test/java/org/spectra/cluster/similarity/CombinedFisherIntensityTestTest.java
@@ -25,6 +25,7 @@ import org.spectra.cluster.model.spectra.IBinarySpectrum;
 import org.spectra.cluster.normalizer.BasicIntegerNormalizer;
 import org.spectra.cluster.normalizer.MaxPeakNormalizer;
 import org.spectra.cluster.normalizer.TideBinner;
+import org.spectra.cluster.predicates.ShareHighestPeaksClusterPredicate;
 
 import java.io.File;
 import java.net.URI;
@@ -168,7 +169,7 @@ public class CombinedFisherIntensityTestTest {
         // perform the clustering
         GreedyClusteringEngine engine = new GreedyClusteringEngine(BasicIntegerNormalizer.MZ_CONSTANT,
                 1, 0.99f, 5,
-                similarity, new MinNumberComparisonsAssessor(10_000), 5);
+                similarity, new MinNumberComparisonsAssessor(10_000), new ShareHighestPeaksClusterPredicate(5));
 
         ICluster[] clusters = engine.clusterSpectra(impSpectra.toArray(new IBinarySpectrum[0]));
 


### PR DESCRIPTION
By default, charge state is taken into consideration when comparing spectra. This can be disabled with a new command line option.

Additionally, I changed the default first round predicate to require 5 shared peaks.

## Benchmark results - accuracy

  * New predicate has no influence on the clustering results
  * Charge state predicate improves accuracy (as expected)

## Benchmark results - speed

  * Original: 62 sec
  * New predicate: 54 sec
  * Charge state (with new predicate): 34 sec

This pull request fixes #70 