### PR TITLE
Added support for parallel incremental clustering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,9 +82,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.bigbio.pgatk</groupId>
+            <groupId>io.github.bigbio.pgatk</groupId>
             <artifactId>pgatk-io</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>${pgatk-io.version}</version>
         </dependency>
 
         <dependency>
@@ -211,6 +211,14 @@
             <id>pst-snapshots</id>
             <name>EBI Nexus Snapshots Repository</name>
             <url>http://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
+        </repository>
+        <repository>
+            <id>sonatype-release</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+        <repository>
+            <id>sonatype-snapshopt</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
     </repositories>
 

--- a/src/main/java/org/spectra/cluster/binning/IClusterBinner.java
+++ b/src/main/java/org/spectra/cluster/binning/IClusterBinner.java
@@ -1,0 +1,22 @@
+package org.spectra.cluster.binning;
+
+import org.spectra.cluster.exceptions.SpectraClusterException;
+import org.spectra.cluster.model.cluster.IClusterProperties;
+
+/**
+ * Bins cluster.
+ */
+public interface IClusterBinner {
+    /**
+     * Bins the specified clusters based on the implementation.
+     *
+     * The result of the binning procedure is returned as a 2-dimensional
+     * array. The first dimension corresponds to the bins which then
+     * contains an array of cluster ids.
+     *
+     * @param clusters The clusters to bin.
+     * @param shift If set, the clusters are shifted by 50%.
+     * @return The binning result as a 2-dimensional array of cluster ids.
+     */
+    String[][] binClusters(IClusterProperties[] clusters, boolean shift) throws SpectraClusterException;
+}

--- a/src/main/java/org/spectra/cluster/binning/SimilarSizedClusterBinner.java
+++ b/src/main/java/org/spectra/cluster/binning/SimilarSizedClusterBinner.java
@@ -1,0 +1,115 @@
+package org.spectra.cluster.binning;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import org.spectra.cluster.exceptions.SpectraClusterException;
+import org.spectra.cluster.model.cluster.IClusterProperties;
+
+import java.util.*;
+
+/**
+ * A cluster binner that bins clusters primarily according to m/z and charge (optional).
+ * Binning is governed by two parameters: the minimum m/z window size and the minimum
+ * number of spectra per bin. Smaller bins are merged into adjacent larger ones.
+ */
+@Data
+public class SimilarSizedClusterBinner implements IClusterBinner {
+    /**
+     * The minimum bin size in (integer changed) m/z.
+     */
+    private final int binSizeMz;
+    /**
+     * Minimum number of cluster per bin before merging clusters.
+     */
+    private final int minimumBinSizeCluster;
+    /**
+     * If set, clusters with different charge states are put in separate bins
+     */
+    private final boolean useCharge;
+
+    @Setter(AccessLevel.NONE)
+    private int precursorOffset;
+
+    @Override
+    public String[][] binClusters(IClusterProperties[] clusters, boolean shift) throws SpectraClusterException {
+        // ensure that there are clusters to bin
+        if (clusters.length < minimumBinSizeCluster) {
+            String[] allIds = Arrays.stream(clusters)
+                    .map(IClusterProperties::getId)
+                    .toArray(String[]::new);
+
+            // return all ids in a single bin
+            return new String[][] { allIds };
+        }
+
+        if (shift)
+            // shifts the assignment of clusters to bins by half the bin size
+            precursorOffset = Math.round((float) binSizeMz / 2);
+        else
+            precursorOffset = 0;
+
+        // get the base binning result
+        Map<Integer, List<String>> bins = doBinning(clusters);
+
+        // merge small bins
+        Integer[] allBins = bins.keySet().stream().sorted().toArray(Integer[]::new);
+
+        for (int binIndex = 0; binIndex < allBins.length - 1; binIndex++) {
+            // merge the bin with the next one if it is too small
+            if (bins.get(allBins[binIndex]).size() < minimumBinSizeCluster) {
+                // add all clusters to the next bin
+                bins.get(allBins[binIndex + 1]).addAll( bins.get(allBins[binIndex]) );
+
+                // put an empty list instead
+                bins.put(allBins[binIndex], new ArrayList<>(0));
+            }
+        }
+
+        // convert to array and remove empty bins
+        String[][] finalBins = bins.values().stream()
+                .filter((List<String> currentBin) -> currentBin.size() > 0)
+                .map((List<String> currentBin) -> currentBin.toArray(new String[0]))
+                .toArray(String[][]::new);
+
+        return finalBins;
+    }
+
+    /**
+     * Performs the initial binning based only on the set bin m/z size and the charge state (if set).
+     *
+     * @param clusters The clusters to bin.
+     * @return A map with the bin index as key and the respective cluster ids as values.
+     * @throws SpectraClusterException
+     */
+    private Map<Integer, List<String>> doBinning(IClusterProperties[] clusters) throws SpectraClusterException {
+        // bin the cluster in the smallest possible bins
+        Map<Integer, List<String>> bins = new HashMap<>(1000);
+
+        for (IClusterProperties cluster : clusters) {
+            // get the "raw" bin
+            int bin = (cluster.getPrecursorMz() + precursorOffset) / binSizeMz;
+
+            // encode the charge as 100_000_000 * charge in the bin #
+            if (useCharge) {
+                if (cluster.getPrecursorCharge() != null) {
+                    // ensure that the charge is plausible
+                    if (cluster.getPrecursorCharge() < 0 || cluster.getPrecursorCharge() > 9)
+                        throw new SpectraClusterException(
+                                String.format("Cluster %s contains unrealistic charge of %d",
+                                        cluster.getId(), cluster.getPrecursorCharge()));
+
+                    // encode the charge
+                    bin += 100_000_000 * cluster.getPrecursorCharge();
+                }
+            }
+
+            if (!bins.containsKey(bin))
+                bins.put(bin, new ArrayList<>(1));
+
+            bins.get(bin).add(cluster.getId());
+        }
+
+        return bins;
+    }
+}

--- a/src/main/java/org/spectra/cluster/io/cluster/ChronicleMapClusterStorage.java
+++ b/src/main/java/org/spectra/cluster/io/cluster/ChronicleMapClusterStorage.java
@@ -6,7 +6,6 @@ import net.openhft.chronicle.map.ChronicleMapBuilder;
 import org.bigbio.pgatk.io.common.PgatkIOException;
 import org.bigbio.pgatk.io.mapcache.IMapStorage;
 import org.spectra.cluster.model.cluster.ICluster;
-import org.spectra.cluster.util.ClusterUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,7 +13,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 @Slf4j
-public class ChronicleMapClusterStorage<V> implements IMapStorage {
+public class ChronicleMapClusterStorage implements IMapStorage<ICluster> {
 
     private static final double CLUSTER_SIZE = 6000 + (200 * 10);
     private static final double CLUSTER_KEY_SIZE = 36 + (100 * 2);
@@ -116,14 +115,18 @@ public class ChronicleMapClusterStorage<V> implements IMapStorage {
     }
 
     @Override
-    public void put(String key, Object value) {
-        ICluster cluster = (ICluster) value;
+    public void put(String key, ICluster cluster) {
         this.clusterStorage.put(key, cluster);
     }
 
     @Override
     public ICluster get(String key) throws PgatkIOException {
         return this.clusterStorage.get(key);
+    }
+
+    @Override
+    public void flush() throws PgatkIOException {
+        // this function has no effect
     }
 
     public Iterator<Map.Entry<String, ICluster>> getIterator(){

--- a/src/main/java/org/spectra/cluster/io/cluster/ClusterStorageFactory.java
+++ b/src/main/java/org/spectra/cluster/io/cluster/ClusterStorageFactory.java
@@ -33,7 +33,7 @@ public class ClusterStorageFactory {
      */
     public static IMapStorage<ICluster> buildTemporaryStaticStorage(File dbDirectory, long numberEntries) throws SpectraClusterException {
         try {
-            return new ChronicleMapClusterStorage<ICluster>(dbDirectory, numberEntries, true);
+            return new ChronicleMapClusterStorage(dbDirectory, numberEntries, true);
         } catch (IOException e) {
             throw new SpectraClusterException("Error creating the ChronicleMap Cluster storage -- " + e.getMessage());
         }
@@ -49,7 +49,7 @@ public class ClusterStorageFactory {
      */
     public static IMapStorage<ICluster> buildPersistentStaticStorage(File dbDirectory, long numberEntries) throws SpectraClusterException {
         try {
-            return new ChronicleMapClusterStorage<ICluster>(dbDirectory, numberEntries, false);
+            return new ChronicleMapClusterStorage(dbDirectory, numberEntries, false);
         } catch (IOException e) {
             throw new SpectraClusterException("Error creating the ChronicleMap Cluster storage -- " + e.getMessage());
         }
@@ -65,7 +65,7 @@ public class ClusterStorageFactory {
      */
     public static IMapStorage<ICluster> openPersistentStaticStorage(File dbDirectory) throws SpectraClusterException {
         try {
-            return new ChronicleMapClusterStorage<ICluster>(dbDirectory, true);
+            return new ChronicleMapClusterStorage(dbDirectory, true);
         } catch (IOException e) {
             throw new SpectraClusterException("Error creating the ChronicleMap Cluster storage -- " + e.getMessage());
         }

--- a/src/main/java/org/spectra/cluster/io/cluster/SparkKeyClusterStorage.java
+++ b/src/main/java/org/spectra/cluster/io/cluster/SparkKeyClusterStorage.java
@@ -9,7 +9,6 @@ import org.bigbio.pgatk.io.mapcache.IMapStorage;
 import org.spectra.cluster.exceptions.SpectraClusterException;
 import org.spectra.cluster.model.cluster.GreedySpectralCluster;
 import org.spectra.cluster.model.cluster.ICluster;
-import org.spectra.cluster.util.ClusterUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,7 +18,7 @@ import java.util.Base64;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class SparkKeyClusterStorage implements IMapStorage {
+public class SparkKeyClusterStorage implements IMapStorage<ICluster> {
 
     private final boolean deleteOnClose;
     private final File dbFile;
@@ -44,7 +43,7 @@ public class SparkKeyClusterStorage implements IMapStorage {
      * @throws IOException
      */
     public SparkKeyClusterStorage(File dbDirectory, Class clusterClass, boolean openExisting, boolean deleteOnClose)
-            throws IOException{
+        throws IOException{
         this.dbFile = new File(dbDirectory, "spectra-cluster_object-storage.spi");
 
         if (openExisting && !this.dbFile.exists())
@@ -103,8 +102,7 @@ public class SparkKeyClusterStorage implements IMapStorage {
     }
 
     @Override
-    public void put(String key, Object value) throws PgatkIOException{
-        ICluster cluster = (ICluster) value;
+    public void put(String key, ICluster cluster) throws PgatkIOException{
         try {
             writers.get().put( serialize(key), cluster.toBytes());
         }catch (IOException | SpectraClusterException ex){
@@ -176,6 +174,7 @@ public class SparkKeyClusterStorage implements IMapStorage {
         }
     }
 
+    @Override
     public void flush() throws PgatkIOException{
         try {
             writers.get().flush();

--- a/src/main/java/org/spectra/cluster/model/cluster/BasicClusterProperties.java
+++ b/src/main/java/org/spectra/cluster/model/cluster/BasicClusterProperties.java
@@ -1,0 +1,10 @@
+package org.spectra.cluster.model.cluster;
+
+import lombok.Data;
+
+@Data
+public class BasicClusterProperties implements IClusterProperties {
+    private final int precursorMz;
+    private final Integer precursorCharge;
+    private final String id;
+}

--- a/src/main/java/org/spectra/cluster/model/cluster/GreedySpectralCluster.java
+++ b/src/main/java/org/spectra/cluster/model/cluster/GreedySpectralCluster.java
@@ -308,6 +308,11 @@ public class GreedySpectralCluster extends LongObject implements ICluster {
 
     }
 
+    @Override
+    public IClusterProperties getProperties() {
+        return new BasicClusterProperties(getPrecursorMz(), getPrecursorCharge(), id);
+    }
+
     public static ICluster fromBytes(byte[] clusterBytes) throws SpectraClusterException {
         ByteArrayInputStream in = new ByteArrayInputStream(clusterBytes);
         ObjectInputStream inputStream = null;

--- a/src/main/java/org/spectra/cluster/model/cluster/ICluster.java
+++ b/src/main/java/org/spectra/cluster/model/cluster/ICluster.java
@@ -15,7 +15,7 @@ import java.util.Set;
  *
  * @author jg
  */
-public interface ICluster extends Serializable, Spectrum {
+public interface ICluster extends Serializable, Spectrum, IClusterProperties {
 
     /**
      * Returns the cluster's id. This is identical with the cluster's consensus spectrum's id.
@@ -87,4 +87,9 @@ public interface ICluster extends Serializable, Spectrum {
      */
     byte[] toBytes() throws SpectraClusterException;
 
+    /**
+     * Returns the cluster's properties as a light-weight object.
+     * @return IClusterProperties object.
+     */
+    IClusterProperties getProperties();
 }

--- a/src/main/java/org/spectra/cluster/model/cluster/IClusterProperties.java
+++ b/src/main/java/org/spectra/cluster/model/cluster/IClusterProperties.java
@@ -1,0 +1,28 @@
+package org.spectra.cluster.model.cluster;
+
+/**
+ * Holds basic information about a cluster.
+ *
+ * This class is intended for tasks like binning and sorting of clusters.
+ */
+public interface IClusterProperties {
+    /**
+     * Returns the cluster's id. This is identical with the cluster's consensus spectrum's id.
+     * @return The cluster's id as String.
+     */
+    String getId();
+
+    /**
+     * The cluster's consensus spectrum's charge
+     *
+     * @return The charge
+     */
+    Integer getPrecursorCharge();
+
+    /**
+     * Returns the cluster's (average) precursor m/z
+     *
+     * @return The cluster's precursor m/z
+     */
+    int getPrecursorMz();
+}

--- a/src/main/java/org/spectra/cluster/tools/LocalParallelBinnedClusteringTool.java
+++ b/src/main/java/org/spectra/cluster/tools/LocalParallelBinnedClusteringTool.java
@@ -1,0 +1,192 @@
+package org.spectra.cluster.tools;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.bigbio.pgatk.io.common.PgatkIOException;
+import org.bigbio.pgatk.io.mapcache.IMapStorage;
+import org.bigbio.pgatk.io.objectdb.LongObject;
+import org.bigbio.pgatk.io.objectdb.ObjectsDB;
+import org.spectra.cluster.binning.IClusterBinner;
+import org.spectra.cluster.cdf.INumberOfComparisonAssessor;
+import org.spectra.cluster.engine.GreedyClusteringEngine;
+import org.spectra.cluster.engine.IClusteringEngine;
+import org.spectra.cluster.exceptions.SpectraClusterException;
+import org.spectra.cluster.io.cluster.ClusterStorageFactory;
+import org.spectra.cluster.io.cluster.ObjectDBGreedyClusterStorage;
+import org.spectra.cluster.model.cluster.GreedySpectralCluster;
+import org.spectra.cluster.model.cluster.ICluster;
+import org.spectra.cluster.model.cluster.IClusterProperties;
+import org.spectra.cluster.predicates.IComparisonPredicate;
+import org.spectra.cluster.similarity.IBinarySpectrumSimilarity;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.concurrent.ForkJoinPool;
+
+/**
+ * This class clusters binned clusters using local temporary files
+ * as storage.
+ *
+ * @author jg
+ */
+@Data
+@Slf4j
+public class LocalParallelBinnedClusteringTool {
+    private final int parallelJobs;
+    private final File temporaryStorageDir;
+    private final IClusterBinner binner;
+    private final Class clusterClass;
+
+    public void runClustering(IClusterProperties[] clusters, IMapStorage<ICluster> clusterStorage, File resultFile,
+                              int precursorTolerance, float thresholdStart, float thresholdEnd,
+                              int clusteringRounds, IBinarySpectrumSimilarity similarityMeasure,
+                              INumberOfComparisonAssessor numberOfComparisonAssessor,
+                              IComparisonPredicate<ICluster> firstRoundPredicate,
+                              int consensusSpectrumNoiseFilterIncrement) throws SpectraClusterException {
+        log.debug("------ Local parallel binned clustering -----");
+
+        try {
+            // bin the spectra
+            log.debug("Binning spectra...");
+            String[][] binnedClusterIds = binner.binClusters(clusters, false);
+
+            log.debug(String.format("Clusters binned in %d bins. Starting parallel clustering using %d threads...", binnedClusterIds.length, parallelJobs));
+
+            // need a temporary storage for the result of the first round
+            File firstRoundStorageDir = new File(temporaryStorageDir.getAbsolutePath(), "first_round");
+            if (!firstRoundStorageDir.mkdir())
+                throw new SpectraClusterException("Failed to create storage directory " + firstRoundStorageDir.getAbsolutePath());
+
+            IMapStorage<ICluster> firstRoundStorage = ClusterStorageFactory.buildTemporaryDynamicStorage(firstRoundStorageDir, clusterClass);
+
+            // ensure that all clusters were written in the initial storage
+            clusterStorage.flush();
+
+            // cluster the initially binned clusters
+            IClusterProperties[][] firstRoundResult = clusterMapped(binnedClusterIds, clusterStorage, firstRoundStorage,
+                    precursorTolerance, thresholdStart, thresholdEnd, clusteringRounds, similarityMeasure,
+                    numberOfComparisonAssessor, firstRoundPredicate, consensusSpectrumNoiseFilterIncrement);
+
+            // close the initial storage
+            clusterStorage.close();
+
+            // flatten the first round result
+            IClusterProperties[] flatFirstRoundResult = Arrays.stream(firstRoundResult)
+                    .flatMap(Arrays::stream)
+                    .toArray(IClusterProperties[]::new);
+
+            // repeat for the second round with shifted windows
+            String[][] rebinnedClusterIds = binner.binClusters(flatFirstRoundResult, true);
+
+            // need another temporary storage for the final result
+            File secondRoundStorageDir = new File(temporaryStorageDir.getAbsolutePath(), "second_round");
+            if (!secondRoundStorageDir.mkdir())
+                throw new SpectraClusterException("Failed to create storage directory " + secondRoundStorageDir.getAbsolutePath());
+
+            IMapStorage<ICluster> secondRoundStorage = ClusterStorageFactory.buildTemporaryDynamicStorage(secondRoundStorageDir, clusterClass);
+
+            // run the clustering again on the re-binned ids
+            IClusterProperties[][] secondRoundResult = clusterMapped(rebinnedClusterIds, firstRoundStorage, secondRoundStorage,
+                    precursorTolerance, thresholdStart, thresholdEnd, clusteringRounds, similarityMeasure,
+                    numberOfComparisonAssessor, firstRoundPredicate, consensusSpectrumNoiseFilterIncrement);
+
+            // close the first round storage - thereby deleting the temporary data
+            firstRoundStorage.close();
+
+            // write the final clusters to file
+            ObjectDBGreedyClusterStorage writer = new ObjectDBGreedyClusterStorage(
+                    new ObjectsDB(resultFile.getAbsolutePath(), true));
+
+            // write all clusters to storage
+            Arrays.stream(secondRoundResult).flatMap(Arrays::stream)
+                    .forEach((IClusterProperties cp) -> {
+                        try {
+                            GreedySpectralCluster cluster = (GreedySpectralCluster) secondRoundStorage.get(cp.getId());
+                            writer.addGreedySpectralCluster(LongObject.asLongHash(cluster.getId()), cluster);
+                        }
+                        catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+
+            // save the final file
+            writer.writeDBMode();
+            writer.flush();
+
+            // close and remove temporary storage
+            secondRoundStorage.close();
+        } catch (Exception e) {
+            throw new SpectraClusterException("Parallel clustering failed", e);
+        }
+    }
+
+    /**
+     * Write clusters to a shared storage.
+     *
+     * The function ensures that only one writing process is active at a time.
+     *
+     * Clusters are stored with their id as key.
+     *
+     * @param storage The storage to use. After writing all clusters, "flush" is called on the storage object.
+     * @param clusters The clusters to write.
+     * @throws PgatkIOException Thrown on I/O errors.
+     */
+    private synchronized void writeClusters(IMapStorage<ICluster> storage, ICluster[] clusters) throws PgatkIOException {
+        log.debug("Writing clusters...");
+        for (ICluster cluster : clusters)  {
+            storage.put(cluster.getId(), cluster);
+        }
+
+        try {
+            storage.flush();
+        } catch (PgatkIOException e) {
+            log.error("Failed to flush clusters");
+            e.printStackTrace();
+            throw e;
+        }
+
+        log.debug("Writing clusters DONE.");
+    }
+
+    private IClusterProperties[][] clusterMapped(String[][] binnedClusterIds, IMapStorage<ICluster> clusterStorage,
+                                                 IMapStorage<ICluster> resultStorage, int precursorTolerance,
+                                                 float thresholdStart, float thresholdEnd,
+                                                 int clusteringRounds, IBinarySpectrumSimilarity similarityMeasure,
+                                                 INumberOfComparisonAssessor numberOfComparisonAssessor,
+                                                 IComparisonPredicate<ICluster> firstRoundPredicate,
+                                                 int consensusSpectrumNoiseFilterIncrement) throws Exception {
+        // start the clustering
+        ForkJoinPool clusteringPool = new ForkJoinPool(parallelJobs, ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true);
+        return clusteringPool.submit(() -> Arrays.stream(binnedClusterIds).parallel().map((String[] clusterIds) -> {
+            try {
+                // TODO: replace with factory for clustering engine
+                IClusteringEngine engine = new GreedyClusteringEngine(precursorTolerance, thresholdStart, thresholdEnd,
+                        clusteringRounds, similarityMeasure, numberOfComparisonAssessor, firstRoundPredicate,
+                        consensusSpectrumNoiseFilterIncrement);
+
+                // load the clusters - parallel reads are not a problem
+                ICluster[] loadedClusters = new ICluster[clusterIds.length];
+
+                for (int i = 0; i < clusterIds.length; i++) {
+                    try {
+                        loadedClusters[i] = clusterStorage.get(clusterIds[i]);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                // run the clustering
+                ICluster[] result = engine.clusterSpectra(loadedClusters);
+
+                // save the clusters
+                writeClusters(resultStorage, result);
+
+                // return the properties
+                return Arrays.stream(result).map(ICluster::getProperties).toArray(IClusterProperties[]::new);
+            } catch (Exception e) {
+                log.error("Clustering failed: " + e.toString());
+                throw new RuntimeException(e);
+            }
+        }).toArray(IClusterProperties[][]::new)).get();
+    }
+}

--- a/src/test/java/org/spectra/cluster/binning/TestSimilarSizedClusterBinner.java
+++ b/src/test/java/org/spectra/cluster/binning/TestSimilarSizedClusterBinner.java
@@ -1,0 +1,118 @@
+package org.spectra.cluster.binning;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.spectra.cluster.model.cluster.BasicClusterProperties;
+import org.spectra.cluster.model.cluster.IClusterProperties;
+import org.spectra.cluster.normalizer.BasicIntegerNormalizer;
+
+public class TestSimilarSizedClusterBinner {
+    @Test
+    public void testBasicBinning() throws Exception {
+        BasicIntegerNormalizer normalizer = new BasicIntegerNormalizer();
+
+        SimilarSizedClusterBinner binner = new SimilarSizedClusterBinner(
+                BasicIntegerNormalizer.MZ_CONSTANT, 1, false);
+
+        IClusterProperties cluster1 = new BasicClusterProperties(
+                normalizer.binValue(300.123), 1, "c1"
+        );
+        IClusterProperties cluster2 = new BasicClusterProperties(
+                normalizer.binValue(300.9), 1, "c2"
+        );
+        IClusterProperties cluster3 = new BasicClusterProperties(
+                normalizer.binValue(301.1), 1, "c3"
+        );
+
+        IClusterProperties[] testCluster = {cluster1, cluster2, cluster3};
+
+        String[][] bins = binner.binClusters(testCluster, false);
+
+        Assert.assertEquals(2, bins.length);
+        Assert.assertEquals(2, bins[0].length);
+        Assert.assertEquals(1, bins[1].length);
+
+        Assert.assertEquals("c3", bins[1][0]);
+    }
+
+    @Test
+    public void testShiftedBinning() throws Exception {
+        BasicIntegerNormalizer normalizer = new BasicIntegerNormalizer();
+
+        SimilarSizedClusterBinner binner = new SimilarSizedClusterBinner(
+                BasicIntegerNormalizer.MZ_CONSTANT, 1, false);
+
+        IClusterProperties cluster1 = new BasicClusterProperties(
+                normalizer.binValue(300.1), 1, "c1"
+        );
+        IClusterProperties cluster2 = new BasicClusterProperties(
+                normalizer.binValue(300.9), 1, "c2"
+        );
+        IClusterProperties cluster3 = new BasicClusterProperties(
+                normalizer.binValue(301.1), 1, "c3"
+        );
+
+        IClusterProperties[] testCluster = {cluster1, cluster2, cluster3};
+
+        String[][] bins = binner.binClusters(testCluster, true);
+
+        Assert.assertEquals(2, bins.length);
+        Assert.assertEquals(1, bins[0].length);
+        Assert.assertEquals(2, bins[1].length);
+
+        Assert.assertEquals("c1", bins[0][0]);
+    }
+
+    @Test
+    public void testCharge() throws Exception {
+        BasicIntegerNormalizer normalizer = new BasicIntegerNormalizer();
+
+        SimilarSizedClusterBinner binner = new SimilarSizedClusterBinner(
+                BasicIntegerNormalizer.MZ_CONSTANT, 1, true);
+
+        IClusterProperties cluster1 = new BasicClusterProperties(
+                normalizer.binValue(300.1), 1, "c1"
+        );
+        IClusterProperties cluster2 = new BasicClusterProperties(
+                normalizer.binValue(300.9), 2, "c2"
+        );
+        IClusterProperties cluster3 = new BasicClusterProperties(
+                normalizer.binValue(301.1), 1, "c3"
+        );
+
+        IClusterProperties[] testCluster = {cluster1, cluster2, cluster3};
+
+        String[][] bins = binner.binClusters(testCluster, false);
+
+        Assert.assertEquals(3, bins.length);
+    }
+
+    @Test
+    public void testMerging() throws Exception {
+        BasicIntegerNormalizer normalizer = new BasicIntegerNormalizer();
+
+        SimilarSizedClusterBinner binner = new SimilarSizedClusterBinner(
+                BasicIntegerNormalizer.MZ_CONSTANT, 2, false);
+
+        IClusterProperties cluster1 = new BasicClusterProperties(
+                normalizer.binValue(300.1), 1, "c1"
+        );
+        IClusterProperties cluster2 = new BasicClusterProperties(
+                normalizer.binValue(300.9), 2, "c2"
+        );
+        IClusterProperties cluster3 = new BasicClusterProperties(
+                normalizer.binValue(301.1), 1, "c3"
+        );
+        IClusterProperties cluster4 = new BasicClusterProperties(
+                normalizer.binValue(303.1), 1, "c4"
+        );
+
+        IClusterProperties[] testCluster = {cluster1, cluster2, cluster3, cluster4};
+
+        String[][] bins = binner.binClusters(testCluster, false);
+
+        Assert.assertEquals(2, bins.length);
+        Assert.assertEquals(2, bins[0].length);
+        Assert.assertEquals(2, bins[1].length);
+    }
+}

--- a/src/test/java/org/spectra/cluster/model/cluster/GreedySpectralClusterTest.java
+++ b/src/test/java/org/spectra/cluster/model/cluster/GreedySpectralClusterTest.java
@@ -19,7 +19,7 @@ public class GreedySpectralClusterTest {
     public void testSavingComparisonMatches() {
         GreedySpectralCluster cluster = new GreedySpectralCluster(new GreedyConsensusSpectrum("Test", GreedyClusteringEngine.COMPARISON_FILTER));
 
-        Assert.assertEquals("Test", cluster.getObjectId());
+        Assert.assertEquals("Test", cluster.getId());
         Assert.assertEquals(0, cluster.getClusteredSpectraCount());
         Assert.assertTrue(cluster.getClusteredSpectraIds().isEmpty());
 
@@ -55,5 +55,31 @@ public class GreedySpectralClusterTest {
 
         Assert.assertEquals(spectra.size(), cluster.getClusteredSpectraCount());
         Assert.assertTrue(cluster.getClusteredSpectraIds().containsAll(spectra.stream().map(IBinarySpectrum::getUUI).collect(Collectors.toList())));
+    }
+
+    @Test
+    public void testGetProperties() throws Exception {
+        File testFile = new File(Objects.requireNonNull(GreedySpectralClusterTest.class.getClassLoader().getResource("same_sequence_cluster.mgf")).toURI());
+        MzSpectraReader reader = new MzSpectraReader(testFile, GreedyClusteringEngine.COMPARISON_FILTER);
+
+        Iterator<IBinarySpectrum> spectrumIterator = reader.readBinarySpectraIterator();
+        List<IBinarySpectrum> spectra = new ArrayList<>();
+
+        while (spectrumIterator.hasNext()) {
+            spectra.add(spectrumIterator.next());
+        }
+
+        // put all spectra to one cluster
+        GreedySpectralCluster cluster = new GreedySpectralCluster(new GreedyConsensusSpectrum("test", GreedyClusteringEngine.COMPARISON_FILTER));
+        cluster.addSpectra(spectra.toArray(new IBinarySpectrum[0]));
+
+        // get the properties
+        IClusterProperties properties = cluster.getProperties();
+
+        int precursorMz = cluster.getPrecursorMz();
+
+        Assert.assertEquals(cluster.getId(), properties.getId());
+        Assert.assertEquals(precursorMz, properties.getPrecursorMz());
+        Assert.assertEquals(cluster.getPrecursorCharge(), properties.getPrecursorCharge());
     }
 }

--- a/src/test/java/org/spectra/cluster/tools/LocalParallelBinnedClusteringToolTest.java
+++ b/src/test/java/org/spectra/cluster/tools/LocalParallelBinnedClusteringToolTest.java
@@ -1,0 +1,139 @@
+package org.spectra.cluster.tools;
+
+import org.bigbio.pgatk.io.mapcache.IMapStorage;
+import org.bigbio.pgatk.io.objectdb.ObjectsDB;
+import org.bigbio.pgatk.io.properties.IPropertyStorage;
+import org.bigbio.pgatk.io.properties.InMemoryPropertyStorage;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.spectra.cluster.binning.SimilarSizedClusterBinner;
+import org.spectra.cluster.cdf.MinNumberComparisonsAssessor;
+import org.spectra.cluster.engine.GreedyClusteringEngine;
+import org.spectra.cluster.filter.binaryspectrum.HighestPeakPerBinFunction;
+import org.spectra.cluster.filter.rawpeaks.*;
+import org.spectra.cluster.io.cluster.ClusterStorageFactory;
+import org.spectra.cluster.io.cluster.ObjectDBGreedyClusterStorage;
+import org.spectra.cluster.io.spectra.MzSpectraReader;
+import org.spectra.cluster.model.cluster.GreedySpectralCluster;
+import org.spectra.cluster.model.cluster.ICluster;
+import org.spectra.cluster.model.cluster.IClusterProperties;
+import org.spectra.cluster.model.consensus.GreedyConsensusSpectrum;
+import org.spectra.cluster.normalizer.BasicIntegerNormalizer;
+import org.spectra.cluster.normalizer.MaxPeakNormalizer;
+import org.spectra.cluster.normalizer.TideBinner;
+import org.spectra.cluster.predicates.ShareHighestPeaksClusterPredicate;
+import org.spectra.cluster.similarity.CombinedFisherIntensityTest;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+public class LocalParallelBinnedClusteringToolTest {
+    private URI[] mgfFiles;
+    private Path testDir;
+
+    @Before
+    public void setUp() throws Exception {
+        mgfFiles = new URI[] {
+                getClass().getClassLoader().getResource("same_sequence_cluster.mgf").toURI(),
+                getClass().getClassLoader().getResource("synthetic_mixed_runs.mgf").toURI(),
+                getClass().getClassLoader().getResource("imp_hela_test.mgf").toURI()
+        };
+
+        testDir = Files.createTempDirectory("clusters-");
+    }
+
+    private IClusterProperties[] loadTestCluster(IMapStorage<ICluster> storage) throws Exception {
+        // ignore the property storage for now
+        IPropertyStorage propertyStorage = new InMemoryPropertyStorage();
+
+        IRawSpectrumFunction loadingFilter = new RemoveImpossiblyHighPeaksFunction()
+                .specAndThen(new RemovePrecursorPeaksFunction(0.5))
+                .specAndThen(new RawPeaksWrapperFunction(new KeepNHighestRawPeaks(40)));
+
+        // create a basic clustering engine for testing
+        GreedyClusteringEngine engine = new GreedyClusteringEngine(BasicIntegerNormalizer.MZ_CONSTANT,
+                1, 0.99f, 5, new CombinedFisherIntensityTest(),
+                new MinNumberComparisonsAssessor(10000), new ShareHighestPeaksClusterPredicate(5),
+                GreedyConsensusSpectrum.NOISE_FILTER_INCREMENT);
+
+        File[] inFiles = Arrays.stream(mgfFiles).map(File::new).toArray(File[]::new);
+
+        // read all files at once
+        MzSpectraReader reader = new MzSpectraReader(new TideBinner(), new MaxPeakNormalizer(),
+                new BasicIntegerNormalizer(), new HighestPeakPerBinFunction(), loadingFilter,
+                GreedyClusteringEngine.COMPARISON_FILTER, engine, inFiles);
+
+        // create the iterator
+        Iterator<ICluster> iterator = reader.readClusterIterator(propertyStorage);
+
+        // keep track of the cluster ids
+        List<IClusterProperties> clusterProperties = new ArrayList<>(10_000);
+
+        while (iterator.hasNext()) {
+            ICluster cluster = iterator.next();
+            String storageId = cluster.getId();
+
+            // store the cluster
+            storage.put(storageId, cluster);
+            clusterProperties.add(cluster.getProperties());
+        }
+
+        return clusterProperties.toArray(new IClusterProperties[0]);
+    }
+
+    @Test
+    public void testParallelClustering() throws Exception {
+        IMapStorage<ICluster> clusterStorageWriter = ClusterStorageFactory.buildDynamicStorage(
+                testDir.toFile(), GreedySpectralCluster.class);
+
+        // load the clusters
+        IClusterProperties[] testClusters = loadTestCluster(clusterStorageWriter);
+
+        clusterStorageWriter.close();
+
+        // open the storage for reading
+        IMapStorage<ICluster> clusterStorage = ClusterStorageFactory.openDynamicStorage(testDir.toFile(),
+                GreedySpectralCluster.class);
+
+        // create the clusterer
+        LocalParallelBinnedClusteringTool clusterer = new LocalParallelBinnedClusteringTool(
+                2, testDir.toFile(),
+                new SimilarSizedClusterBinner(BasicIntegerNormalizer.MZ_CONSTANT * 2, 10, false),
+                GreedySpectralCluster.class);
+
+        File finalResultFile = new File(testDir.toFile(), "result.bcs");
+
+        clusterer.runClustering(testClusters, clusterStorage, finalResultFile,
+            BasicIntegerNormalizer.MZ_CONSTANT,
+            1, 0.99f, 5, new CombinedFisherIntensityTest(),
+            new MinNumberComparisonsAssessor(10000), new ShareHighestPeaksClusterPredicate(5),
+            GreedyConsensusSpectrum.NOISE_FILTER_INCREMENT);
+
+        // make sure the final result file exists
+        Assert.assertTrue(finalResultFile.exists());
+
+        // open the final result
+        ObjectDBGreedyClusterStorage resultReader = new ObjectDBGreedyClusterStorage(new ObjectsDB(finalResultFile.getAbsolutePath(), false));
+        int totalClusters = 0;
+        int totalSpectra = 0;
+
+        while (resultReader.hasNext()) {
+            GreedySpectralCluster cluster = (GreedySpectralCluster) resultReader.next();
+
+            totalClusters++;
+
+            // count the number of spectra
+            totalSpectra += cluster.getClusteredSpectraCount();
+        }
+
+        Assert.assertEquals(6958, totalClusters);
+        Assert.assertEquals(testClusters.length, totalSpectra);
+    }
+}

--- a/src/test/java/org/spectra/cluster/tools/LocalParallelBinnedClusteringToolTest.java
+++ b/src/test/java/org/spectra/cluster/tools/LocalParallelBinnedClusteringToolTest.java
@@ -42,9 +42,7 @@ public class LocalParallelBinnedClusteringToolTest {
     public void setUp() throws Exception {
         mgfFiles = new URI[] {
                 getClass().getClassLoader().getResource("same_sequence_cluster.mgf").toURI(),
-                getClass().getClassLoader().getResource("synthetic_mixed_runs.mgf").toURI(),
-                getClass().getClassLoader().getResource("imp_hela_test.mgf").toURI()
-        };
+                getClass().getClassLoader().getResource("synthetic_mixed_runs.mgf").toURI()};
 
         testDir = Files.createTempDirectory("clusters-");
     }
@@ -133,7 +131,7 @@ public class LocalParallelBinnedClusteringToolTest {
             totalSpectra += cluster.getClusteredSpectraCount();
         }
 
-        Assert.assertEquals(6958, totalClusters);
+        Assert.assertEquals(192, totalClusters);
         Assert.assertEquals(testClusters.length, totalSpectra);
     }
 }


### PR DESCRIPTION
Key changes are:

## Added light-weight class to store cluster properties

The IClusterProperties interface allows us to only retain key informations about a cluster. The list of these properties is then used to bin the clusters and subsequently start the clustering.

## Added binning infrastructure

Added the IClusterBinner interface and the SimilarSizedClusterBinner class to bin clusters as a prerequisite for parallel clustering.

## Updated SparkeyStorage for multi-threading

Sparkey only supports a single writer for each database (multiple readers are OK). Updated the class accordingly.

## Add parallel clustering infrastructure

Added the new LocalParallelBinnedClusteringTool. This class bins the clusters and then runs the clustering using multiple threads. It also takes care of storing the clusters in SparkeyStorages during the clustering. Thereby, only the lowest number of clusters possible are kept in memory.

# Issues

This PR fixes/enchances #92 #87 #58 